### PR TITLE
Shapeways tweaks

### DIFF
--- a/key/dishes.scad
+++ b/key/dishes.scad
@@ -14,6 +14,9 @@ module  dish(width, height, depth, inverted, tilt) {
 		else if ($dish_type == "sideways cylindrical"){
 			sideways_cylindrical_dish(width, height, depth, inverted, tilt);
 		}
+		else if ($dish_type == "old spherical") {
+			old_spherical_dish(width, height, depth, inverted, tilt);
+		}
 		// else no dish, "no dish" is the value
 }
 
@@ -68,10 +71,12 @@ module spherical_dish(width, height, depth, inverted, tilt, txt=""){
 		rotate([-tilt,0,0]){
 			translate([0,0,0 * direction]){
 				if (geodesic){
-					$fa=10;
-					geodesic_sphere(r=rad);
+					$fa=20;
+					scale([chord/2/depth, chord/2/depth]) {
+						geodesic_sphere(r=depth);
+					}
 				} else {
-					$fa=1;
+					$fa=7;
 					// rotate 1 because the bottom of the sphere looks like trash.
 					scale([chord/2/depth, chord/2/depth]) {
 						geodesic_sphere(r=depth);
@@ -102,15 +107,12 @@ module old_spherical_dish(width, height, depth, inverted, tilt, txt=""){
 		rotate([-tilt,0,0]){
 			translate([0,0,chord_length * direction]){
 				if (geodesic){
-					$fa=3;
+					$fa=7;
 					geodesic_sphere(r=rad);
 				} else {
 					$fa=1;
-					// rotate 1 because the bottom of the sphere looks like trash.
-					%difference() {
-						sphere(r=rad);
-						translate([0,0,rad]) cube(rad*2, center=true);
-					}
+					// rotate 1 because the bottom of the sphere looks like trash
+					sphere(r=rad);
 				}
 	    }
 		}

--- a/key/keys.scad
+++ b/key/keys.scad
@@ -6,6 +6,7 @@
 // special variables, but that's a limitation of SCAD we have to work around
 
 /* TODO:
+ * add keys.scad function for fudge factor in stem
  * pull out side sculpting options to let people tweak them?
  * can now measure keycaps very accurately. need to redo measurements: [x] SA [ ] DCS [X] DSA [X] OEM?
  * Add inset stem to all profiles that need it. [x] OEM [ ] DCS?
@@ -43,6 +44,7 @@ $text = "";
 $inset_text = false;
 $corner_radius = 1;
 $height_slices = 1;
+$slop = 0.3;
 
 // key profile definitions
 
@@ -392,17 +394,20 @@ module blank() {
   children();
 }
 
-module cherry() {
+module cherry(slop = 0.3) {
+	$slop = slop;
   $stem_profile = "cherry";
   children();
 }
 
-module alps() {
+module alps(slop = 0.3) {
+	$slop = slop;
   $stem_profile = "alps";
   children();
 }
 
-module rounded_cherry() {
+module rounded_cherry(slop = 0.3) {
+	$slop = slop;
   $stem_profile = "cherry_rounded";
   children();
 }
@@ -413,8 +418,4 @@ module legend(text, inset=false) {
 	children();
 }
 
-rows = [4,3,2,1,5];
-
-
-translate_u(0, 0) dcs_row(1) cherry() key() {
-};
+translate_u(0, 0) oem_row(1) cherry() key();

--- a/key/stems.scad
+++ b/key/stems.scad
@@ -11,7 +11,9 @@ module brim(has_brim) {
   if (has_brim) color([0,1,0]) cube([brim_radius, brim_radius, brim_depth]);
 }
 
-module cherry_stem(has_brim, slop = 0.3) {
+module cherry_stem(has_brim, slop) {
+
+  echo(slop);
 
   stem_width = 7.2 - slop * 2;
   stem_height = 5.5 - slop * 2;
@@ -48,12 +50,12 @@ module cherry_stem(has_brim, slop = 0.3) {
   }
 }
 
-module cherry_stem_rounded(has_brim) {
+module cherry_stem_rounded(has_brim, slop) {
   // cross length
   cross_length = 4.4;
   //dimensions of connector
   // outer cross extra length in y
-  extra_outer_cross_height = 1.0;
+  extra_outer_cross_height = 1.1;
   // dimensions of cross
   // horizontal cross bar width
   horizontal_cross_width = 1.4;
@@ -78,7 +80,7 @@ module cherry_stem_rounded(has_brim) {
   }
 }
 
-module alps_stem(has_brim = false){
+module alps_stem(has_brim, slop){
 	cross_depth = 40;
 	width = 4.45;
 	height = 2.25;
@@ -92,7 +94,7 @@ module alps_stem(has_brim = false){
 	}
 }
 
-module filled_stem(has_brim=false) {
+module filled_stem() {
   // this is mostly for testing. we don't pass the size of the keycp in here
   // so we can't make this work for all keys
   cube(100, center=true);
@@ -100,13 +102,14 @@ module filled_stem(has_brim=false) {
 
 
 //whole connector, alps or cherry, trimmed to fit
-module connector(stem_profile, has_brim){
+module connector(stem_profile, has_brim, slop){
+  echo(slop);
 		if (stem_profile == "alps") {
-			alps_stem(has_brim);
+			alps_stem(has_brim, slop);
 		} else if (stem_profile == "cherry_rounded") {
-			cherry_stem_rounded(has_brim);
+			cherry_stem_rounded(has_brim, slop);
 		} else if (stem_profile == "cherry") {
-			cherry_stem(has_brim);
+			cherry_stem(has_brim, slop);
 		} else if (stem_profile == "filled") {
       filled_stem();
     }


### PR DESCRIPTION
gearing up for the V2 release, I bought a few models off shapeways that I'm going to get photographed. In doing so I added a few tweaks to the codebase, seen here.

couple render blocks to make re-rendering a bit faster, some dishing tweaks, a new monospaced font, a new default minkowski radius and static inset lettering depth, as well as a slop variable you can pass to stem functions (`cherry(slop = 0.2) key()`) that adds a little breathing room on the stem. the more accurate the printer, the closer you can run this number to 0