### PR TITLE
Fixed brimmed(), minor enhancements

### DIFF
--- a/key/keys.scad
+++ b/key/keys.scad
@@ -38,3 +38,6 @@ for (p = [0:len(key_profiles)-1]) {
 }
 
 /* translate_u(0, 0) one_row_profile("oem"); */
+
+dcs_row(3) cherry() legend("X", "top", "left", 3) legend("X") key(true);
+translate_u(1, 0) dcs_row(3) cherry() legend("M", "top", "left", 3) legend("Z") key(true);

--- a/key/redox_keys.scad
+++ b/key/redox_keys.scad
@@ -16,16 +16,27 @@ include <src/key_types.scad>
 include <src/key_transformations.scad>
 
 //select the keyset profile options are: ["dcs", "oem", "sa", "g20", "dsa"]
-profile = "oem";
-//select weather or not to sculpt the keys by row (you probably want true for dsa only)
+profile = "dsa";
+//select weather or not to sculpt the keys by row (set to true for real dsa keys or they will just be shorter sa keys)
 unsculpted = false;
 //choose if legends are inset or raised above the surface of the keys.
 legend_inset = true;
 //place a home row bump on the F and J keys
 home_row_bump = true;
+//regular legend font size (default is 6)
+//$font_size = 6;
+//symbol legend font size (symbols being arrows/enter/shift/backspace etc)
+sym_size = 10;
+//shifted key press font size
+alt_size = 4.5;
+//multi character font size
+word_size = 4;
+
+
 
 //used for selecting the profile row in a loop.
-rows = [5,1,2,3,4];
+//rows = [5,1,2,3,4];
+rows = [1,2,3,4,3];
 
 module translate_u(x=0, y=0, z=0){
   translate([x * unit, y*unit, z*unit]) children();
@@ -35,29 +46,25 @@ module keypf(row) {
    key_profile(profile, unsculpted ? 3 : row) brimmed(0.25) cherry() key(legend_inset);
 }
 
-module make_keys(keys) {
-    for (i=[0:len(keys)-1]) {
+module make_keys(keys, scol=undef, ecol=undef) {
+    ascol = scol == undef ? 0 : scol;
+    aecol = ecol == undef ? len(keys) - 1 : ecol;
+    for (i=[ascol:aecol]) {
         for (j=[0:len(keys[i])-1]) {
             if ((keys[i][j][0] == "F" || keys[i][j][0] == "J") && home_row_bump && len(keys[i][j]) == 1)
                 translate_u(i, -j) legend(keys[i][j][0]) bump() keypf(rows[j]);
             else if ((keys[i][j][0] == "F" || keys[i][j][0] == "J") && home_row_bump && len(keys[i][j]) == 2)
-                translate_u(i, -j) legend(keys[i][j][1], "top", "left", 3) legend(keys[i][j][0]) bump() keypf(rows[j]);
+                translate_u(i, -j) legend(keys[i][j][1], "top", size=alt_size) legend(keys[i][j][0], "bottom", size=alt_size) bump() keypf(rows[j]);
             else if (len(keys[i][j]) == 1)
                 translate_u(i, -j) legend(keys[i][j][0]) keypf(rows[j]);
             else if (len(keys[i][j]) == 2)
-                translate_u(i, -j) legend(keys[i][j][1], "top", "left", 3) legend(keys[i][j][0]) keypf(rows[j]);
+                translate_u(i, -j) legend(keys[i][j][1], "top", size=alt_size) legend(keys[i][j][0], "bottom", size=alt_size) keypf(rows[j]);
         }
     }
 }
 
-module make_1_25_col(keys) {
-    for (i=[0:len(keys)-1]) {
-        translate_u(0, -i) 1_25u() legend(keys[i]) keypf(rows[i]);
-    }
-}
-
 //left hand alphanumeric keys
-module alphanum_left() {
+module alphanum_left(scol=undef, ecol=undef) {
     keysdef = [
         [["1", "!"], ["Q"], ["A"], ["Z"]],
         [["2", "@"], ["W"], ["S"], ["X"]],
@@ -65,48 +72,66 @@ module alphanum_left() {
         [["4", "$"], ["R"], ["F"], ["V"]],
         [["5", "%"], ["T"], ["G"], ["B"]]
     ];
-    make_keys(keysdef);
+    make_keys(keysdef, scol, ecol);
 }
 
 //left hand 1.25u modifier keys
 module mod_left_outside() {
-    translate_u(-1.125, 0) make_1_25_col(["ESC","TAB","CLK",chr(8657)]);
+    translate_u(-1.125, 0) 1_25u() legend("ESC") keypf(1);
+    translate_u(-1.125, -1) 1_25u() legend("TAB") keypf(2);
+    translate_u(-1.125, -2) 1_25u() legend("CLK") keypf(3);
+    translate_u(-1.125, -3) 1_25u() legend(chr(8657), size=sym_size) keypf(4);
 }
 
 //left hand bottom row modifier keys
-module mod_left_bottom() {
-    translate_u(-1, -4) legend("`") legend("~", "top", "left", 3) keypf(4);
-    translate_u(0, -4) legend("CTRL", size=4) keypf(4);
-    translate_u(1, -4) keypf(4);
-    translate_u(2, -4) legend("ALT", size=4) keypf(4);
-    translate_u(3.125, -4) 1_25u()legend("fn", size=4) keypf(4);
+module mod_left_bottom(half=undef) {
+    if (half == undef || half == "left") {
+        translate_u(-1, -4) legend("CTRL", size=word_size) keypf(3);
+        translate_u(0, -4) legend("LYR", size=word_size) keypf(3);
+        translate_u(1, -4) legend("GUI", size=word_size) keypf(3);
+        translate_u(2, -4) legend("ALT", size=word_size) keypf(3);
+    }
+    if (half == undef || half == "right") translate_u(3.125, -4) 1_25u() legend(chr(8657), size=sym_size) keypf(3);
 }
 
 //left hand center modifier keys
 module mod_left_inside() {
-    translate_u(5, 0) legend("-") legend("_", "top", "left", 3) keypf(5);
-    translate_u(5, -1.125) 1_25uh() legend("[") legend("{", "top", "left", 3) keypf(1);
+    translate_u(5, -0.125) 1_25uh() legend("[", "bottom", size=alt_size) legend("{", "top", size=alt_size) keypf(2);
+    translate_u(5, -1.375) 1_25uh() legend("-", "bottom") legend("_", "top") keypf(3);
 }
 
 //left hand thumb cluster modifier keys
 module mod_left_thumb() {
-    translate_u(5, -3) legend("HOME", size=4) keypf(3);
-    translate_u(6, -3) legend("END", size=4) keypf(3);
-    translate_u(5, -4.25) 1_5uh() legend(chr(9003)) keypf(3);
-    translate_u(6, -4.25)  1_5uh() legend(chr(8998)) keypf(3);
+    translate_u(5, -3) legend("", size=word_size) keypf(2);
+    translate_u(6, -3) legend(chr(8998), size=sym_size) keypf(2);
+    translate_u(5, -4.25) 1_5uh() keypf(3);
+    translate_u(6, -4.25)  1_5uh() legend(chr(9003), size=sym_size) keypf(3);
 }
 
-//render the entire left hand key set
-module left() {
-    alphanum_left();
-    mod_left_outside();
-    mod_left_bottom();
-    mod_left_inside();
-    mod_left_thumb();
+//render the entire left hand key set (or a half of a half for smaller printable groups)
+module left(half=undef) {
+    if (half == "left") {
+        alphanum_left(0, 2);
+        mod_left_outside();
+        mod_left_bottom("left");
+    }
+    else if (half == "right") {
+        alphanum_left(3, 4);
+        mod_left_bottom("right");
+        mod_left_inside();
+        mod_left_thumb();
+    }
+    else {
+        alphanum_left();
+        mod_left_outside();
+        mod_left_bottom();
+        mod_left_inside();
+        mod_left_thumb();
+    }
 }
 
 //right hand alphanumeric keys
-module alphanum_right() {
+module alphanum_right(scol=undef, ecol=undef) {
     keysdef = [
         [["6", "^"], ["Y"], ["H"], ["N"]],
         [["7", "&"], ["U"], ["J"], ["M"]],
@@ -114,44 +139,62 @@ module alphanum_right() {
         [["9", "("], ["O"], ["L"], [".", ">"]],
         [["0", ")"], ["P"], [";", ":"], ["/", "?"]]
     ];
-    make_keys(keysdef);
+    make_keys(keysdef, scol, ecol);
 }
 
 //right hand 1.25u modifier keys
 module mod_right_outside() {
-    translate_u(5.125, 0) make_1_25_col([chr(9003),"\\",chr(8629),chr(8657)]);
+    translate_u(5.125, 0) 1_25u() legend(chr(9003), size=sym_size) keypf(1);
+    translate_u(5.125, -1) 1_25u() legend("\\", "bottom", size=alt_size) legend("|", "top", size=alt_size) keypf(2);
+    translate_u(5.125, -2) 1_25u() legend("'", "bottom", size=alt_size) legend("\"", "top", size=alt_size) keypf(3);
+    translate_u(5.125, -3) 1_25u() legend(chr(8657), size=sym_size) keypf(4);
 }
 
 //right hand bottom row modifier keys
-module mod_right_bottom() {
-    translate_u(5, -4) legend(chr(9654)) keypf(4);
-    translate_u(4, -4) legend(chr(9660)) keypf(4);
-    translate_u(3, -4) legend(chr(9650)) keypf(4);
-    translate_u(2, -4) legend(chr(9664)) keypf(4);
-    translate_u(0.875, -4) 1_25u() legend("fn", size=4) keypf(4);
+module mod_right_bottom(half=undef) {
+    if (half == undef || half == "right") {
+        translate_u(5, -4) legend(chr(9654)) keypf(3);
+        translate_u(4, -4) legend(chr(9660)) keypf(3);
+        translate_u(3, -4) legend(chr(9650)) keypf(3);
+        translate_u(2, -4) legend(chr(9664)) keypf(3);
+    }
+    if (half == undef || half == "left") translate_u(0.875, -4) 1_25u() legend(chr(8657), size=sym_size) keypf(3);
 }
 
 //right hand center modifier keys
 module mod_right_inside() {
-    translate_u(-1, 0) legend("=") legend("+", "top", "left", 3) keypf(1);
-    translate_u(-1, -1.125) 1_25uh() legend("]") legend("}", "top", "left", 3) keypf(2);
+    translate_u(-1, -0.125) 1_25uh() legend("]", "bottom", size=alt_size) legend("}", "top", size=alt_size) keypf(2);
+    translate_u(-1, -1.375) 1_25uh() legend("=", "bottom") legend("+", "top") keypf(3);
 }
 
 //right hand thum cluster modifier keys
 module mod_right_thumb() {
-    translate_u(-1, -3) legend("PGDN", size=4) keypf(3);
-    translate_u(-2, -3) legend("PGUP", size=4) keypf(3);
+    translate_u(-1, -3) legend("PGDN", size=word_size) keypf(2);
+    translate_u(-2, -3) legend("PGUP", size=word_size) keypf(2);
     translate_u(-1, -4.25) 1_5uh() keypf(3);
-    translate_u(-2, -4.25) 1_5uh() legend(chr(8629)) keypf(3);
+    translate_u(-2, -4.25) 1_5uh() legend(chr(8629), size=sym_size) keypf(3);
 }
 
 //render entire right hand key set
-module right() {
-    alphanum_right();
-    mod_right_outside();
-    mod_right_bottom();
-    mod_right_thumb();
-    mod_right_inside();
+module right(half=undef) {
+    if (half == "left") {
+        alphanum_right(0, 1);
+        mod_right_bottom("left");
+        mod_right_thumb();
+        mod_right_inside();
+    }
+    else if (half == "right") {
+        alphanum_right(2, 4);
+        mod_right_outside();
+        mod_right_bottom("right");
+    }
+    else {
+        alphanum_right();
+        mod_right_outside();
+        mod_right_bottom();
+        mod_right_thumb();
+        mod_right_inside();
+    }
 }
 
 
@@ -161,14 +204,20 @@ module right() {
 
 //individual sections for printing (keep stl output clusters close together for better slicing)
 //left();
+//left("left");
+//left("right");
 //alphanum_left();
 //mod_left_outside();
 //mod_left_bottom();
 //mod_left_inside();
 //mod_left_thumb();
 //right();
+//right("left");
+//right("right");
 //alphanum_right();
 //mod_right_outside();
 //mod_right_bottom();
 //mod_right_thumb();
 //mod_right_inside();
+
+//inverted()

--- a/key/redox_keys.scad
+++ b/key/redox_keys.scad
@@ -1,0 +1,174 @@
+/*
+keyset generator for the redox keyboard found here: https://www.thingiverse.com/thing:2704567
+
+Modify the "profile", "unsculpted", "legend_inset", "home_row_bump" to achieve desired results.
+
+Select what to render at the bottom of the file (which modules to call) (everything is commented out
+by default...
+
+Modify key legends with the "legend" function in each module (or keysdef in the case of alpha numeric keys)
+*/
+use <src/key.scad>
+include <src/settings.scad>
+include <src/key_sizes.scad>
+include <src/key_profiles.scad>
+include <src/key_types.scad>
+include <src/key_transformations.scad>
+
+//select the keyset profile options are: ["dcs", "oem", "sa", "g20", "dsa"]
+profile = "oem";
+//select weather or not to sculpt the keys by row (you probably want true for dsa only)
+unsculpted = false;
+//choose if legends are inset or raised above the surface of the keys.
+legend_inset = true;
+//place a home row bump on the F and J keys
+home_row_bump = true;
+
+//used for selecting the profile row in a loop.
+rows = [5,1,2,3,4];
+
+module translate_u(x=0, y=0, z=0){
+  translate([x * unit, y*unit, z*unit]) children();
+}
+
+module keypf(row) {
+   key_profile(profile, unsculpted ? 3 : row) brimmed(0.25) cherry() key(legend_inset);
+}
+
+module make_keys(keys) {
+    for (i=[0:len(keys)-1]) {
+        for (j=[0:len(keys[i])-1]) {
+            if ((keys[i][j][0] == "F" || keys[i][j][0] == "J") && home_row_bump && len(keys[i][j]) == 1)
+                translate_u(i, -j) legend(keys[i][j][0]) bump() keypf(rows[j]);
+            else if ((keys[i][j][0] == "F" || keys[i][j][0] == "J") && home_row_bump && len(keys[i][j]) == 2)
+                translate_u(i, -j) legend(keys[i][j][1], "top", "left", 3) legend(keys[i][j][0]) bump() keypf(rows[j]);
+            else if (len(keys[i][j]) == 1)
+                translate_u(i, -j) legend(keys[i][j][0]) keypf(rows[j]);
+            else if (len(keys[i][j]) == 2)
+                translate_u(i, -j) legend(keys[i][j][1], "top", "left", 3) legend(keys[i][j][0]) keypf(rows[j]);
+        }
+    }
+}
+
+module make_1_25_col(keys) {
+    for (i=[0:len(keys)-1]) {
+        translate_u(0, -i) 1_25u() legend(keys[i]) keypf(rows[i]);
+    }
+}
+
+//left hand alphanumeric keys
+module alphanum_left() {
+    keysdef = [
+        [["1", "!"], ["Q"], ["A"], ["Z"]],
+        [["2", "@"], ["W"], ["S"], ["X"]],
+        [["3", "#"], ["E"], ["D"], ["C"]],
+        [["4", "$"], ["R"], ["F"], ["V"]],
+        [["5", "%"], ["T"], ["G"], ["B"]]
+    ];
+    make_keys(keysdef);
+}
+
+//left hand 1.25u modifier keys
+module mod_left_outside() {
+    translate_u(-1.125, 0) make_1_25_col(["ESC","TAB","CLK",chr(8657)]);
+}
+
+//left hand bottom row modifier keys
+module mod_left_bottom() {
+    translate_u(-1, -4) legend("`") legend("~", "top", "left", 3) keypf(4);
+    translate_u(0, -4) legend("CTRL", size=4) keypf(4);
+    translate_u(1, -4) keypf(4);
+    translate_u(2, -4) legend("ALT", size=4) keypf(4);
+    translate_u(3.125, -4) 1_25u()legend("fn", size=4) keypf(4);
+}
+
+//left hand center modifier keys
+module mod_left_inside() {
+    translate_u(5, 0) legend("-") legend("_", "top", "left", 3) keypf(5);
+    translate_u(5, -1.125) 1_25uh() legend("[") legend("{", "top", "left", 3) keypf(1);
+}
+
+//left hand thumb cluster modifier keys
+module mod_left_thumb() {
+    translate_u(5, -3) legend("HOME", size=4) keypf(3);
+    translate_u(6, -3) legend("END", size=4) keypf(3);
+    translate_u(5, -4.25) 1_5uh() legend(chr(9003)) keypf(3);
+    translate_u(6, -4.25)  1_5uh() legend(chr(8998)) keypf(3);
+}
+
+//render the entire left hand key set
+module left() {
+    alphanum_left();
+    mod_left_outside();
+    mod_left_bottom();
+    mod_left_inside();
+    mod_left_thumb();
+}
+
+//right hand alphanumeric keys
+module alphanum_right() {
+    keysdef = [
+        [["6", "^"], ["Y"], ["H"], ["N"]],
+        [["7", "&"], ["U"], ["J"], ["M"]],
+        [["8", "*"], ["I"], ["K"], [",", "<"]],
+        [["9", "("], ["O"], ["L"], [".", ">"]],
+        [["0", ")"], ["P"], [";", ":"], ["/", "?"]]
+    ];
+    make_keys(keysdef);
+}
+
+//right hand 1.25u modifier keys
+module mod_right_outside() {
+    translate_u(5.125, 0) make_1_25_col([chr(9003),"\\",chr(8629),chr(8657)]);
+}
+
+//right hand bottom row modifier keys
+module mod_right_bottom() {
+    translate_u(5, -4) legend(chr(9654)) keypf(4);
+    translate_u(4, -4) legend(chr(9660)) keypf(4);
+    translate_u(3, -4) legend(chr(9650)) keypf(4);
+    translate_u(2, -4) legend(chr(9664)) keypf(4);
+    translate_u(0.875, -4) 1_25u() legend("fn", size=4) keypf(4);
+}
+
+//right hand center modifier keys
+module mod_right_inside() {
+    translate_u(-1, 0) legend("=") legend("+", "top", "left", 3) keypf(1);
+    translate_u(-1, -1.125) 1_25uh() legend("]") legend("}", "top", "left", 3) keypf(2);
+}
+
+//right hand thum cluster modifier keys
+module mod_right_thumb() {
+    translate_u(-1, -3) legend("PGDN", size=4) keypf(3);
+    translate_u(-2, -3) legend("PGUP", size=4) keypf(3);
+    translate_u(-1, -4.25) 1_5uh() keypf(3);
+    translate_u(-2, -4.25) 1_5uh() legend(chr(8629)) keypf(3);
+}
+
+//render entire right hand key set
+module right() {
+    alphanum_right();
+    mod_right_outside();
+    mod_right_bottom();
+    mod_right_thumb();
+    mod_right_inside();
+}
+
+
+//show entire set
+//left();
+//translate_u(10) right();
+
+//individual sections for printing (keep stl output clusters close together for better slicing)
+//left();
+//alphanum_left();
+//mod_left_outside();
+//mod_left_bottom();
+//mod_left_inside();
+//mod_left_thumb();
+//right();
+//alphanum_right();
+//mod_right_outside();
+//mod_right_bottom();
+//mod_right_thumb();
+//mod_right_inside();

--- a/key/src/key.scad
+++ b/key/src/key.scad
@@ -161,10 +161,12 @@ module top_of_key(){
 	}
 }
 
-module keytext(text, depth = 0) {
-	translate([0, 0, -depth]){
+module keytext(text, halign, valign, font_size, depth) {
+    woffset = (top_total_key_width()/3.5) * (halign == "center" ? 0 : halign == "left" ? -1 : 1);
+    hoffset = (top_total_key_height()/3.5) * (valign == "center" ? 0 : valign == "bottom" ? -1 : 1);
+	translate([woffset, hoffset, -depth]){
 		linear_extrude(height=$dish_depth){
-			text(text=text, font=$font, size=$font_size, halign="center", valign="center");
+			text(text=text, font=$font, size=font_size, halign="center", valign="center");
 		}
 	}
 }
@@ -217,10 +219,12 @@ module clearance_check() {
 }
 
 // legends / artisan support
-module artisan(legend, depth) {
+module artisan(depth) {
 	top_of_key() {
 		// outset legend
-		if (legend != "") keytext(legend, depth);
+        for (i=[0:len($legends)-1]) {
+            keytext($legends[i][0], $legends[i][1], $legends[i][2], $legends[i][3], depth);
+        }
 		// artisan objects / outset shape legends
 		children();
 	}
@@ -244,19 +248,19 @@ module keytop() {
 
 // The final, penultimate key generation function.
 // takes all the bits and glues them together. requires configuration with special variables.
-module key(legend = "", inset = false) {
+module key(inset = false) {
 	difference() {
 		union(){
 			// the shape of the key, inside and out
 			keytop();
 			// additive objects at the top of the key
-			if(!inset) artisan(legend) children();
+			if(!inset) artisan() children();
 			// render the clearance check if it's enabled, but don't have it intersect with anything
 			if ($clearance_check) %clearance_check();
 		}
 
 		// subtractive objects at the top of the key
-		if (inset) artisan(legend, 0.3) children();
+		if (inset) artisan(0.3) children();
 		// subtract the clearance check if it's enabled, letting the user see the
 		// parts of the keycap that will hit the cherry switch
 		if ($clearance_check) clearance_check();

--- a/key/src/key.scad
+++ b/key/src/key.scad
@@ -171,6 +171,14 @@ module keytext(text, halign, valign, font_size, depth) {
 	}
 }
 
+module keybump(depth = 0, edge_inset=0.4) {
+    radius = 0.5;
+	translate([0, -top_total_key_height()/2 + edge_inset, depth]){
+        rotate([90,0,90]) cylinder($font_size, radius, radius, true);
+        translate([0,0,-radius]) cube([$font_size, radius*2, radius*2], true);
+	}
+}
+
 module keystem_positions() {
 	for (connector_pos = $connectors) {
 		translate(connector_pos) {
@@ -253,6 +261,7 @@ module key(inset = false) {
 		union(){
 			// the shape of the key, inside and out
 			keytop();
+            if($key_bump) top_of_key() keybump($key_bump_depth, $key_bump_edge);
 			// additive objects at the top of the key
 			if(!inset) artisan() children();
 			// render the clearance check if it's enabled, but don't have it intersect with anything

--- a/key/src/key_profiles/dsa.scad
+++ b/key/src/key_profiles/dsa.scad
@@ -1,9 +1,10 @@
 module dsa_row(n=3) {
+    depth_raisers = [0, 3.5, 1, 0, 1, 3];
 	$bottom_key_width = 18.24; // 18.4;
 	$bottom_key_height = 18.24; // 18.4;
 	$width_difference = 6; // 5.7;
 	$height_difference = 6; // 5.7;
-	$total_depth = 8.1 + abs((n-3) * 1);
+	$total_depth = 8.1 + depth_raisers[n];
 	$top_tilt = n == 5 ? -21 : (n-3) * 7;
 	$top_skew = 0;
 	$dish_type = "spherical";

--- a/key/src/key_profiles/g20.scad
+++ b/key/src/key_profiles/g20.scad
@@ -12,6 +12,8 @@ module g20_row(n=3) {
 	$dish_skew_x = 0;
 	$dish_skew_y = 0;
 	$minkowski_radius = 1.75;
+    $key_bump_depth = 0.6;
+    $key_bump_edge = 2;
   //also,
 	$rounded_key = true;
 

--- a/key/src/key_transformations.scad
+++ b/key/src/key_transformations.scad
@@ -107,3 +107,9 @@ module legend(text, valign="center", halign="center", size=0) {
     $legends = [for(L=[$legends, [[text, halign, valign, size > 0 ? size : $font_size]]], a=L) a];
     children();
 }
+
+module bump(depth=undef) {
+    $key_bump = true;
+    $key_bump_depth = depth == undef ? $key_bump_depth : depth;
+    children();
+}

--- a/key/src/key_transformations.scad
+++ b/key/src/key_transformations.scad
@@ -7,8 +7,9 @@ module translate_u(x=0, y=0, z=0){
   translate([x * unit, y*unit, z*unit]) children();
 }
 
-module brimmed() {
+module brimmed(height = 0.2) {
   $has_brim = true;
+  $brim_height = height;
   children();
 }
 

--- a/key/src/key_transformations.scad
+++ b/key/src/key_transformations.scad
@@ -100,3 +100,10 @@ module flat_support() {
   $support_type = "flat";
   children();
 }
+
+module legend(text, valign="center", halign="center", size=0) {
+    //valign = "top" or "center" or "bottom"
+    //halign = "left" or "center" or "right"
+    $legends = [for(L=[$legends, [[text, halign, valign, size > 0 ? size : $font_size]]], a=L) a];
+    children();
+}

--- a/key/src/settings.scad
+++ b/key/src/settings.scad
@@ -114,4 +114,10 @@ $alps_stem = [4.45, 2.25];
 //halign = "left" or "center" or "right"
 //valign = "top" or "center" or "bottom"
 $legends = [];
+//insert locating bump
+$key_bump = false;
+//height of the location bump from the top surface of the key
+$key_bump_depth = 0.3;
+//distance to move the bump from the front edge of the key
+$key_bump_edge = 0.4;
 

--- a/key/src/settings.scad
+++ b/key/src/settings.scad
@@ -41,6 +41,8 @@ $key_length = 1;
 $key_height = 1;
 //print brim for connector to help with bed adhesion
 $has_brim = false;
+//when $has_brim this is the height of the brim
+$brim_height = 0.2;
 // invert dishing. mostly for spacebar
 $inverted_dish = false;
 // array of positions of all stems. includes stabilizers as well, for now

--- a/key/src/settings.scad
+++ b/key/src/settings.scad
@@ -109,3 +109,9 @@ $rounded_cherry_stem_d = 5.5;
 
 // dimensions of alps stem
 $alps_stem = [4.45, 2.25];
+
+//list of legends to place on a key format: [text, halign, valign, size]
+//halign = "left" or "center" or "right"
+//valign = "top" or "center" or "bottom"
+$legends = [];
+

--- a/key/src/settings.scad
+++ b/key/src/settings.scad
@@ -117,7 +117,7 @@ $legends = [];
 //insert locating bump
 $key_bump = false;
 //height of the location bump from the top surface of the key
-$key_bump_depth = 0.3;
+$key_bump_depth = 0.5;
 //distance to move the bump from the front edge of the key
 $key_bump_edge = 0.4;
 

--- a/key/src/stems/alps.scad
+++ b/key/src/stems/alps.scad
@@ -1,10 +1,12 @@
 module alps_stem(depth, has_brim){
   if(has_brim) {
-    linear_extrude(h=brim_height) {
-      square($alps_stem * [2,2], center = true);
+    linear_extrude(height=$brim_height) {
+      offset(r=1){
+        square($alps_stem + [2,2], center=true);
+      }
     }
   }
-  linear_extrude(h=depth) {
+  linear_extrude(height=depth) {
     square($alps_stem, center = true);
   }
 }

--- a/key/src/stems/cherry.scad
+++ b/key/src/stems/cherry.scad
@@ -10,9 +10,9 @@ module cherry_stem(depth, has_brim) {
 
       // brim, if applicable
       if(has_brim) {
-        linear_extrude(height = brim_height){
+        linear_extrude(height = $brim_height){
           offset(r=1){
-            square($cherry_stem - [2,2], center=true);
+            square($cherry_stem + [2,2], center=true);
           }
         }
       }

--- a/key/src/stems/rounded_cherry.scad
+++ b/key/src/stems/rounded_cherry.scad
@@ -3,7 +3,7 @@ module rounded_cherry_stem(depth, has_brim) {
     union(){
       cylinder(d=$rounded_cherry_stem_d, h=depth);
       if(has_brim) {
-        cylinder(d=$rounded_cherry_stem_d * 2, h=brim_height);
+        cylinder(d=$rounded_cherry_stem_d * 2, h=$brim_height);
       }
     }
 


### PR DESCRIPTION
Fixed:
* brimmed() didn't work as no brim_height was defined.

Added:
* brimmed() now accepts a height to make it easier to specify.
```brimmed(0.25) cherry() key();```
* key() now accepts bump option for home row keys (F/J)
```brimmed(0.25) cherry() key("J", true, true);```
* key() now accepts multi line legends:
```brimmed(0.25) cherry() key("! \n1", true);```