### PR TITLE
Allow more subtle side sculpting of SA/DSA to make the tops less square.

### DIFF
--- a/key/src/settings.scad
+++ b/key/src/settings.scad
@@ -75,6 +75,8 @@ $dish_overdraw_height = 0;
 $height_slices = 1;
 // this enables some fancy and currently hardcoded logic to bow the sides and corners of SA keycaps
 $enable_side_sculpting = false;
+// this enables even more fancy and hardcoded logic for corner bowing of SA keycaps. (Also needs enable_side_sculpting to be true)
+$enable_more_side_sculpting = false;
 
 //minkowski radius. radius of sphere used in minkowski sum for minkowski_key function. 1.75 for G20
 $minkowski_radius = .33;

--- a/key/src/settings.scad
+++ b/key/src/settings.scad
@@ -77,6 +77,12 @@ $height_slices = 1;
 $enable_side_sculpting = false;
 // this enables even more fancy and hardcoded logic for corner bowing of SA keycaps. (Also needs enable_side_sculpting to be true)
 $enable_more_side_sculpting = false;
+// When sculpting sides, how much in should the tops come
+$side_sculpting_factor = 2.5;
+// When sculpting corners, how much extra radius should be added
+$corner_sculpting_factor = 1;
+// When doing more side sculpting corners, how much extra radius should be added
+$more_side_sculpting_factor = 0.4;
 
 //minkowski radius. radius of sphere used in minkowski sum for minkowski_key function. 1.75 for G20
 $minkowski_radius = .33;

--- a/key/src/shapes/rounded_square.scad
+++ b/key/src/shapes/rounded_square.scad
@@ -1,8 +1,8 @@
 // side sculpting functions
 // bows the sides out on stuff like SA and DSA keycaps
-function side_sculpting(progress) = (1 - progress) * 2.5;
+function side_sculpting(progress) = (1 - progress) * $side_sculpting_factor;
 // makes the rounded corners of the keycap grow larger as they move upwards
-function corner_sculpting(progress) = pow(progress, 2);
+function corner_sculpting(progress) = pow(progress, 2) * $corner_sculpting_factor;
 
 module rounded_square_shape(size, delta, progress, center = true) {
 		width = size[0];
@@ -23,7 +23,7 @@ module rounded_square_shape(size, delta, progress, center = true) {
                 square_size = [width - extra_width_this_slice, height - extra_height_this_slice];
 		offset(r = extra_corner_radius_this_slice) offset(r = -extra_corner_radius_this_slice) {
                     if ($enable_more_side_sculpting != false && progress > 0) {
-                        side_rounded_square(square_size, r = 0.4 * progress);
+                        side_rounded_square(square_size, r = $more_side_sculpting_factor * progress);
                     } else {
 			square(square_size, center=center);
                     }

--- a/key/src/shapes/rounded_square.scad
+++ b/key/src/shapes/rounded_square.scad
@@ -20,13 +20,60 @@ module rounded_square_shape(size, delta, progress, center = true) {
 		extra_height_this_slice = (height_difference - extra_side_size) * progress;
 		extra_corner_radius_this_slice = ($corner_radius + extra_corner_size);
 
-		offset(r=extra_corner_radius_this_slice){
-			square(
-				[
-					width - extra_width_this_slice - extra_corner_radius_this_slice * 2,
-					height - extra_height_this_slice - extra_corner_radius_this_slice * 2
-				],
-				center=center
-			);
+                square_size = [width - extra_width_this_slice, height - extra_height_this_slice];
+		offset(r = extra_corner_radius_this_slice) offset(r = -extra_corner_radius_this_slice) {
+                    if ($enable_more_side_sculpting != false && progress > 0) {
+                        side_rounded_square(square_size, r = 0.4 * progress);
+                    } else {
+			square(square_size, center=center);
+                    }
 		}
+}
+
+// Brings in a square at each corner by r, applied over the length of each side.
+module side_rounded_square(size, r) {
+    if ($enable_more_side_sculpting == "slow") {
+        side_rounded_square_slow(size, r);
+    } else {
+        side_rounded_square_fast(size, r);
+    }
+}
+module side_rounded_square_fast(size, r) {
+    iw = size.x - 2 * r;
+    ih = size.y - 2 * r;
+    resolution = 100;
+    sr = r / resolution * 2;
+    sh = ih / resolution;
+    sw = iw / resolution;
+    union() {
+        translate([-iw/2, 0]) scale([sr, sh]) circle(d = resolution);
+        translate([iw/2, 0]) scale([sr, sh]) circle(d = resolution);
+        translate([0, -ih/2]) scale([sw, sr]) circle(d = resolution);
+        translate([0, ih/2]) scale([sw, sr]) circle(d = resolution);
+        square([iw, ih], center=true);
+    }
+}
+module side_rounded_square_slow(size, r) {
+    // These two from: https://openscadsnippetpad.blogspot.co.nz/2017/05/circle-defined-by-three-points.html
+    function len3(v) = sqrt(pow(v.x, 2) + pow(v.y, 2));
+    function circle_by_three_points(A, B, C) = let (
+        yD_b = C.y - B.y,  xD_b = C.x - B.x,  yD_a = B.y - A.y,
+        xD_a = B.x - A.x,  aS = yD_a / xD_a,  bS = yD_b / xD_b,
+        cex = (aS * bS * (A.y - C.y) + bS * (A.x + B.x) - aS * (B.x + C.x)) / (2 * (bS - aS)),
+        cey = -1 * (cex - (A.x + B.x) / 2) / aS + (A.y + B.y) / 2
+        )
+        [cex, cey];
+
+    w = size.x - r * 2;
+    h = size.y - r * 2;
+    cw = circle_by_three_points([-w / 2, 0], [0, r], [w / 2, 0]);
+    rw = len3([w / 2, 0] - cw);
+    ch = circle_by_three_points([0, -h / 2], [r, 0], [0, h / 2]);
+    rh = len3([0, h / 2] - ch);
+    intersection() {
+        translate(cw + [0, h / 2]) circle(r = rw, $fa=1);
+        translate(cw * -1 + [0, -h / 2]) circle(r = rw, $fa=1);
+        translate(ch + [w / 2, 0]) circle(r = rh, $fa=1);
+        translate(ch * -1 + [-w / 2, 0]) circle(r = rh, $fa=1);
+    }
 }


### PR DESCRIPTION
Thanks for this fantastic project you've put together, it's so comprehensive!

I am printing some SA profile keycaps so I can (inexpensively) get an idea as to whether I would like the profile enough to buy some of the more expensive sets. I've never seen any in person. Anyway, after some minor tweaks to get things going nicely on my printer (slop = 0.4, enable brim, use bar supports) they're coming out very nicely in PLA, and it's making me want to try ABS with some vapour polishing.

In some pictures I've seen (more so SP SA than MAXKEYS), it looks like the key tops are slightly more curved/rounded than the current sculpting you had here. E.g: http://www.griffy.no/Pics/keyboard/Dasher/1.jpg

I had a go at adding a little more to it. Try this out and let me know if this is something that real keycaps have, or if it's just my imagination (or perhaps due to perspective in photos). Example comparison at: https://i.imgur.com/vE2RR5u.png

To enable this, you need to set

    $enable_more_side_sculpting = true

(as well as ensuring that the existing `enable_side_sculpting` is set).

There is also an additional method for doing the extra sculpting that
can be enabled via:

    $enable_more_side_sculpting = "slow"

(This slow method was actually my first attempt which looks nice at 1u but doesn't
scale nicely to wider/taller keys.)
