### PR TITLE
Add small chamfer at base of stem.

### DIFF
--- a/key/src/stems/cherry.scad
+++ b/key/src/stems/cherry.scad
@@ -25,6 +25,11 @@ module cherry_stem(depth, has_brim) {
         square($cherry_cross[0], center=true);
         square($cherry_cross[1], center=true);
       }
+      // Guides to assist insertion and mitigate first layer squishing
+      for (i = $cherry_cross) hull() {
+        linear_extrude(height = 0.01, center = false) offset(delta = 0.4) square(i, center=true);
+        translate([0, 0, 0.5]) linear_extrude(height = 0.01, center = false)  square(i, center=true);
+      }
     }
   }
 }


### PR DESCRIPTION
The keycaps I have have a small chamfer at the base of the stems.

As well as helping guide insertion of the stems, it also helps with FDM printing, where the first layer might be a little squished, so having the chamfer means little to no post-print cleanup before they can be mounted.

I've only done it for the square section stem (that's what I've been using), it might need adjustment before porting to the other stem types (I haven't used them).

![cross-chamfer](https://user-images.githubusercontent.com/282098/40267467-c5b14606-5bb0-11e8-8d36-9ce6214f7f13.png)
