### PR TITLE
Break out stabilizers from stems

### DIFF
--- a/key/keys.scad
+++ b/key/keys.scad
@@ -40,15 +40,17 @@ for (p = [0:len(key_profiles)-1]) {
 /* translate_u(0, 0) one_row_profile("oem"); */
 /* dsa_row(3) u(1) uh(1) cherry() key(); */
 
-translate_u(0) sa_row(3) cherry() {
+translate_u(0, 0) sa_row(3) stepped_caps_lock() {
   key();
 }
 
-translate_u(1) sa_row(2) cherry() {
+translate_u(0, 1) sa_row(2) lshift() {
+  $stem_type = false;
   key();
 }
 
-translate_u(2) sa_row(1) cherry() {
+translate_u(0, 2) sa_row(1) spacebar() alps() {
+  $support_type = false;
   key();
 }
 

--- a/key/src/key.scad
+++ b/key/src/key.scad
@@ -173,8 +173,8 @@ module keytext(text, position, font_size, depth) {
   }
 }
 
-module keystem_positions() {
-  for (connector_pos = $connectors) {
+module keystem_positions(positions) {
+  for (connector_pos = positions) {
     translate(connector_pos) {
       rotate([0, 0, $stem_rotation]){
         children();
@@ -183,15 +183,15 @@ module keystem_positions() {
   }
 }
 
-module keystems() {
-  keystem_positions() {
-    color(color4) stem($stem_type, $total_depth, $has_brim, $stem_slop);
+module support_for(positions, stem_type) {
+  keystem_positions(positions) {
+    color(color4) supports($support_type, stem_type, $stem_throw, $total_depth - $stem_throw);
   }
 }
 
-module keystem_supports() {
-  keystem_positions() {
-    color(color4) supports($support_type, $stem_type, $stem_throw, $total_depth - $stem_throw);
+module stems_for(positions, stem_type) {
+  keystem_positions(positions) {
+    color(color4) stem(stem_type, $total_depth, $has_brim, $stem_slop);
   }
 }
 
@@ -270,15 +270,25 @@ module key(inset = false) {
   }
 
   // both stem and support are optional
-  if ($stem_type){
+  if ($stem_type || $stabilizer_type) {
     dished($keytop_thickness, $inverted_dish) {
-      translate([0, 0, $stem_inset]) keystems();
+      translate([0, 0, $stem_inset]) {
+        if ($stabilizer_type) stems_for($stabilizers, $stabilizer_type);
+        if ($stem_type) stems_for($stem_positions, $stem_type);
+      }
     }
   }
 
   if ($support_type){
     inside() {
-      translate([0, 0, $stem_inset]) keystem_supports();
+      translate([0, 0, $stem_inset]) {
+        if ($stabilizer_type) support_for($stabilizers, $stabilizer_type);
+
+        // always render stem support even if there isn't a stem.
+        // rendering flat support w/no stem is much more common than a hollow keycap
+        // so if you want a hollow keycap you'll have to turn support off entirely
+        support_for($stem_positions, $stem_type);
+      }
     }
   }
 }

--- a/key/src/key_transformations.scad
+++ b/key/src/key_transformations.scad
@@ -28,18 +28,18 @@ module rotated() {
   children();
 }
 
-module stabilized(mm=12, vertical = false) {
+module stabilized(mm=12, vertical = false, type="cherry") {
   if (vertical) {
-    $connectors = [
-    [0,   0],
+    $stabilizer_type = type;
+    $stabilizers = [
     [0,  mm],
     [0, -mm]
     ];
 
     children();
   } else {
-    $connectors = [
-      [0,   0],
+    $stabilizer_type = type;
+    $stabilizers = [
       [mm,  0],
       [-mm, 0]
     ];

--- a/key/src/key_types.scad
+++ b/key/src/key_types.scad
@@ -34,9 +34,7 @@ module numpad_0() {
 
 module stepped_caps_lock() {
   u(1.75) {
-    $connectors = [
-      [-5, 0]
-    ];
+    $stem_positions = [[-5, 0]];
     children();
   }
 }

--- a/key/src/settings.scad
+++ b/key/src/settings.scad
@@ -45,9 +45,9 @@ $has_brim = false;
 $brim_height = 0.2;
 // invert dishing. mostly for spacebar
 $inverted_dish = false;
-// array of positions of all stems. includes stabilizers as well, for now
+// array of positions of stabilizers
 // ternary is a bad hack to keep the stabilizers flag working
-$connectors = $stabilizers ? [[0,0],[-50,0],[50,0]] : [[0,0]];
+$stabilizers = [[-50,0],[50,0]];
 // use linear_extrude instead of hull slices to make the shape of the key
 // should be faster, also required for concave shapes
 $linear_extrude_shape = false;
@@ -55,6 +55,10 @@ $linear_extrude_shape = false;
 $rounded_key = false;
 // what type of stem you want. To turn off stems pass false. "cherry", "alps", and "cherry_rounded" supported
 $stem_type = "cherry";
+// where the stems are in relation to the center of the keycap, in units. default is one in the center
+$stem_positions = [[0,0]];
+// what type of stem you want for the stabilizers. false disables
+$stabilizer_type = false;
 // how much higher the stem is than the bottom of the keycap.
 // inset stem requires support but is more accurate in some profiles
 $stem_inset = 0;

--- a/key/src/supports/flared.scad
+++ b/key/src/supports/flared.scad
@@ -9,14 +9,7 @@ function scale_for_45(height, starting_size) = (height * 2 + starting_size) / st
 // also kind of messy... oh well
 module flared_support(stem_type, loft, height) {
   translate([0,0,loft]){
-    if(stem_type == "cherry") {
-      cherry_scale = [scale_for_45(height, outer_cherry_stem()[0]), scale_for_45(height, outer_cherry_stem()[1])];
-      linear_extrude(height=height, scale = cherry_scale){
-        offset(r=1){
-          square(outer_cherry_stem() - [2,2], center=true);
-        }
-      }
-    } else if (stem_type == "cherry_rounded") {
+    if (stem_type == "cherry_rounded") {
       linear_extrude(height=height, scale = scale_for_45(height, $rounded_cherry_stem_d)){
         circle(d=$rounded_cherry_stem_d);
       }
@@ -24,6 +17,15 @@ module flared_support(stem_type, loft, height) {
       alps_scale = [scale_for_45(height, $alps_stem[0]), scale_for_45(height, $alps_stem[1])];
       linear_extrude(height=height, scale = alps_scale){
         square($alps_stem, center=true);
+      }
+    } else {
+      // always render cherry if no stem type. this includes stem_type = false!
+      // this avoids a bug where the keycap is rendered filled when not desired
+      cherry_scale = [scale_for_45(height, outer_cherry_stem()[0]), scale_for_45(height, outer_cherry_stem()[1])];
+      linear_extrude(height=height, scale = cherry_scale){
+        offset(r=1){
+          square(outer_cherry_stem() - [2,2], center=true);
+        }
       }
     }
   }


### PR DESCRIPTION
Apparently alps keyboards have cherry style stabilizers! Really should have gotten a matias keyboard by now. 

This PR breaks out stabilizers from keystems, they each have their own array of positions now, as well as their own type, allowing you to define multiple keystems and multiple stabilizers of different profiles. Notably this also gets rid of the original 'stabilizers' variable, which enabled -50mm and 50mm stabilizers by default. I'll have to figure out how to do something for that in the customizer version when I get to it 