### PR TITLE
Switch to generating the customizer file via a script

### DIFF
--- a/key/README.md
+++ b/key/README.md
@@ -137,6 +137,8 @@ Prints from this library are still challenging, despite all efforts to the contr
 That's it, if you have any questions feel free to open an issue or leave a comment on thingiverse!
 
 ## TODO:
+ * switch dishing logic from a super large cube to a bounding box intersection
+ * update this documentation!
  * replace linear_extrude_shape_hull with skin_extrude_shape_hull or something, to enable concave extrusions
  * replace current ISO enter shape with one that works for `skin()`
  * generate dishes via math? kind of hard, maybe later

--- a/key/README.md
+++ b/key/README.md
@@ -137,6 +137,7 @@ Prints from this library are still challenging, despite all efforts to the contr
 That's it, if you have any questions feel free to open an issue or leave a comment on thingiverse!
 
 ## TODO:
+ * enable customizer to print spacebars
  * switch dishing logic from a super large cube to a bounding box intersection
  * update this documentation!
  * replace linear_extrude_shape_hull with skin_extrude_shape_hull or something, to enable concave extrusions

--- a/key/README.md
+++ b/key/README.md
@@ -137,7 +137,6 @@ Prints from this library are still challenging, despite all efforts to the contr
 That's it, if you have any questions feel free to open an issue or leave a comment on thingiverse!
 
 ## TODO:
- * enable customizer to print spacebars
  * switch dishing logic from a super large cube to a bounding box intersection
  * update this documentation!
  * replace linear_extrude_shape_hull with skin_extrude_shape_hull or something, to enable concave extrusions

--- a/key/customizer.scad
+++ b/key/customizer.scad
@@ -1,47 +1,45 @@
 // entry point for customizer script. This probably isn't useful to most people,
 // as it's just a wrapper that helps generate customizer.scad for thingiverse.
 
-/* [Key] */
+/* [Basic-Settings] */
 
-//length in units of key
+// what preset profile do you wish to use? disable if you are going to set paramters below
+key_profile = "dcs"; // [dcs, oem, dsa, sa, g20, disable]
+// what key profile row is this keycap on? 0 for disable
+row = 1; // [5,1,2,3,4,0]
+
+// What does the top of your key say?
+legend = "";
+
+/* [Basic-Settings] */
+
+// what type of stem you want. Most people want Cherry.
+$stem_type = "cherry";  // [cherry, alps, rounded_cherry, filled, disable]
+
+// support type. default is "flared" for easy FDM printing. to disable pass false
+$support_type = "flared"; // [flared, bars, flat, disable]
+
+//length in units of key. A regular key is 1 unit; spacebar is usually 6.25
 $key_length = 1;
-//height in units of key. should remain 1 for most uses
-$key_height = 1;
-
-/* [Brim] */
 
 //print brim for connector to help with bed adhesion
 $has_brim = false;
-// how tall in mm the brim is, if there is one. brim sits around the keystem and helps to secure it while printing.
-$brim_height = 0.4;
-// what type of stem you want. To turn off stems pass false. "cherry", "alps", and "cherry_rounded" supported
 
-/* [Stem] */
-// What stem do you want to use?
-$stem_type = "cherry";  // [cherry, alps, rounded_cherry, filled]
-// how much higher the stem is than the bottom of the keycap.
-// inset stem requires support but is more accurate in some profiles
-$stem_inset = 0;
-// how many degrees to rotate the stems. useful for sideways keycaps, maybe
-$stem_rotation = 0;
 // the stem is the hardest part to print, so this variable controls how much 'slop' there is in the stem
 $stem_slop = 0.3;
-
-/* [Support] */
-
-// support type. default is "flared" for easy FDM printing. to disable pass false
-$support_type = "flared"; // [flared, bars, flat]
-
-/* [Misc] */
 
 // font size used for text
 $font_size = 6;
 
+// invert dishing. mostly for spacebar
+$inverted_dish = false;
 
-/* [Advanced Features] */
+
+/* [Advanced] */
 
 /* Key */
-
+// height in units of key. should remain 1 for most uses
+$key_height = 1;
 // keytop thickness, aka how many millimeters between the inside and outside of the top surface of the key
 $keytop_thickness = 1;
 // wall thickness, aka the thickness of the sides of the keycap. note this is the total thickness, aka 3 = 1.5mm walls
@@ -74,6 +72,12 @@ $rounded_cherry_stem_d = 5.5;
 // dimensions of alps stem
 $alps_stem = [4.45, 2.25];
 
+// how much higher the stem is than the bottom of the keycap.
+// inset stem requires support but is more accurate in some profiles
+$stem_inset = 0;
+// how many degrees to rotate the stems. useful for sideways keycaps, maybe
+$stem_rotation = 0;
+
 /* Stabilizers */
 
 // array of positions of stabilizers
@@ -95,15 +99,13 @@ $height_slices = 1;
 /* Dish */
 
 // what type of dish the key has. note that unlike stems and supports a dish ALWAYS gets rendered.
-$dish_type = "cylindrical"; // [cylindrical, spherical, sideways cylindrical, old spherical]
+$dish_type = "cylindrical"; // [cylindrical, spherical, sideways cylindrical, old spherical, disable]
 // how deep the dish 'digs' into the top of the keycap. this is max depth, so you can't find the height from total_depth - dish_depth. besides the top is skewed anyways
 $dish_depth = 1;
 // how skewed in the x direction the dish is
 $dish_skew_x = 0;
 // how skewed in the y direction (height) the dish is
 $dish_skew_y = 0;
-// invert dishing. mostly for spacebar
-$inverted_dish = false;
 // if you need the dish to extend further, you can 'overdraw' the rectangle it will hit
 $dish_overdraw_width = 0;
 // same as width but for height
@@ -111,6 +113,8 @@ $dish_overdraw_height = 0;
 
 /* Misc */
 
+// how tall in mm the brim is, if there is one. brim sits around the keystem and helps to secure it while printing.
+$brim_height = 0.4;
 // font used for text
 $font="DejaVu Sans Mono:style=Book";
 // whether or not to render fake keyswitches to check clearances
@@ -241,6 +245,8 @@ module dcs_row(n=1) {
     $total_depth = 6;
     $top_tilt = 16;
     children();
+  } else {
+    children();
   }
 }
 module oem_row(n=1) {
@@ -275,16 +281,16 @@ module oem_row(n=1) {
     $total_depth = 9.25;
     $top_tilt = 10;
     children();
+  } else {
+    children();
   }
 }
 module dsa_row(n=3) {
   $key_shape_type = "sculpted_square";
-  depth_raisers = [0, 3.5, 1, 0, 1, 3];
   $bottom_key_width = 18.24; // 18.4;
   $bottom_key_height = 18.24; // 18.4;
   $width_difference = 6; // 5.7;
   $height_difference = 6; // 5.7;
-  $total_depth = 8.1 + depth_raisers[n];
   $top_tilt = n == 5 ? -21 : (n-3) * 7;
   $top_skew = 0;
   $dish_type = "spherical";
@@ -297,7 +303,25 @@ module dsa_row(n=3) {
   // do you even minkowski bro
   $corner_radius = 0.25;
 
-  children();
+  depth_raisers = [0, 3.5, 1, 0, 1, 3];
+  if (n == 5) {
+    $total_depth = 8.1 + depth_raisers[n];
+    children();
+  } else if (n == 1) {
+    $total_depth = 8.1 + depth_raisers[n];
+    children();
+  } else if (n == 2) {
+    $total_depth = 8.1 + depth_raisers[n];
+    children();
+  } else if (n == 3) {
+    $total_depth = 8.1 + depth_raisers[n];
+    children();
+  } else if (n == 4) {
+    $total_depth = 8.1 + depth_raisers[n];
+    children();
+  } else {
+    children();
+  }
 }
 module sa_row(n=1) {
   $key_shape_type = "sculpted_square";
@@ -334,6 +358,8 @@ module sa_row(n=1) {
     $total_depth = 12.925;
     $top_tilt = 7;
     children();
+  } else {
+    children();
   }
 }
 module g20_row(n=3) {
@@ -341,22 +367,41 @@ module g20_row(n=3) {
   $bottom_key_height = 18.16;
   $width_difference = 2;
   $height_difference = 2;
-  $total_depth = 6 + abs((n-3) * 0.5);
   $top_tilt = 2.5;
-  $top_tilt =  n == 5 ? -18.5 : (n-3) * 7 + 2.5;
   $top_skew = 0.75;
-  $dish_type = "no dish";
+  $dish_type = "disable";
   $dish_depth = 0;
   $dish_skew_x = 0;
   $dish_skew_y = 0;
   $minkowski_radius = 1.75;
-    $key_bump_depth = 0.6;
-    $key_bump_edge = 2;
+  $key_bump_depth = 0.6;
+  $key_bump_edge = 2;
   //also,
   $rounded_key = true;
 
-
-  children();
+  if (n == 5) {
+    $total_depth = 6 + abs((n-3) * 0.5);
+    $top_tilt =  -18.55;
+    children();
+  } else if (n == 1) {
+    $total_depth = 6 + abs((n-3) * 0.5);
+    $top_tilt = (n-3) * 7 + 2.5;
+    children();
+  } else if (n == 2) {
+    $total_depth = 6 + abs((n-3) * 0.5);
+    $top_tilt = (n-3) * 7 + 2.5;
+    children();
+  } else if (n == 3) {
+    $total_depth = 6 + abs((n-3) * 0.5);
+    $top_tilt = (n-3) * 7 + 2.5;
+    children();
+  } else if (n == 4) {
+    $total_depth = 6 + abs((n-3) * 0.5);
+    $top_tilt = (n-3) * 7 + 2.5;
+    children();
+  } else {
+    children();
+  }
 }
 
 // man, wouldn't it be so cool if functions were first order
@@ -371,6 +416,10 @@ module key_profile(key_profile_type, row) {
     sa_row(row) children();
   } else if (key_profile_type == "g20") {
     g20_row(row) children();
+  } else if (key_profile_type == "disable") {
+    children();
+  } else {
+    echo("Warning: unsupported key_profile_type");
   }
 }
 module spacebar() {
@@ -811,6 +860,8 @@ module stem(stem_type, depth, has_brim, slop){
       cherry_stem(depth, has_brim, slop);
     } else if (stem_type == "filled") {
       filled_stem();
+    } else if (stem_type == "disable") {
+      children();
     } else {
       echo("Warning: unsupported $stem_type");
     }
@@ -1025,10 +1076,10 @@ module  dish(width, height, depth, inverted) {
     }
     else if ($dish_type == "old spherical") {
       old_spherical_dish(width, height, depth, inverted);
+    } else if ($dish_type == "disable") {
+      // else no dish
     } else {
-      // else no dish, "no dish" is the value
-      // switchted to actually diffing a cube here due to changes to stems being differenced from the dish instead of the inside
-      translate([0,0,500]) cube([width, height, 1000], center=true);
+      echo("WARN: $dish_type unsupported");
     }
 }
 // cherry stem dimensions
@@ -1082,6 +1133,8 @@ module supports(type, stem_type, loft, height) {
     flat(stem_type, loft, height);
   } else if (type == "bars") {
     bars(stem_type, loft, height);
+  } else if (type == "disable") {
+    children();
   } else {
     echo("Warning: unsupported $support_type");
   }
@@ -1333,13 +1386,20 @@ module _dish() {
 
 // for when you want to take the dish out of things
 // used for adding the dish to the key shape and making sure stems don't stick out the top
+// has physical limits, since you can't specify planes in openscad
+// maybe I should make a bounding box cube, difference that with the dish then intersect with the children
 module dished(depth_difference, inverted = false) {
   difference() {
     children();
     top_placement(depth_difference){
       difference(){
         union() {
-          translate([-500, -500]) cube(1000);
+          // this weird math here is so Customizer doesn't see a giant shape and zoom out a million miles. could just be cube(1000)
+          translate([-$key_length * unit, -$key_height * unit]) cube([
+            $key_length*2 * unit,
+            $key_height*2 * unit,
+            50
+          ]);
           if (!inverted) _dish();
         }
         if (inverted) _dish();
@@ -1352,7 +1412,7 @@ module dished(depth_difference, inverted = false) {
 // more user-friendly than top_placement
 module top_of_key(){
   // if there is a dish, we need to account for how much it digs into the top
-  dish_depth = ($dish_type == "no dish") ? 0 : $dish_depth;
+  dish_depth = ($dish_type == "disable") ? 0 : $dish_depth;
   // if the dish is inverted, we need to account for that too. in this case we do half, otherwise the children would be floating on top of the dish
   corrected_dish_depth = ($inverted_dish) ? -dish_depth / 2 : dish_depth;
 
@@ -1409,7 +1469,7 @@ module cherry_keyswitch() {
 
 //approximate (fully depressed) cherry key to check clearances
 module clearance_check() {
-  if($stem_type == "cherry" || $stem_type == "rounded_cherry"){
+  if($stem_type == "cherry" || $stem_type == "cherry_rounded"){
     color(transparent_red){
       translate([0,0,3.6 + $stem_inset - 5]) {
         cherry_keyswitch();
@@ -1468,19 +1528,19 @@ module key(inset = false) {
   }
 
   // both stem and support are optional
-  if ($stem_type || $stabilizer_type) {
+  if ($stem_type != "disable" || $stabilizer_type != "disable") {
     dished($keytop_thickness, $inverted_dish) {
       translate([0, 0, $stem_inset]) {
-        if ($stabilizer_type) stems_for($stabilizers, $stabilizer_type);
-        if ($stem_type) stems_for($stem_positions, $stem_type);
+        if ($stabilizer_type != "disable") stems_for($stabilizers, $stabilizer_type);
+        if ($stem_type != "disable") stems_for($stem_positions, $stem_type);
       }
     }
   }
 
-  if ($support_type){
+  if ($support_type != "disable"){
     inside() {
       translate([0, 0, $stem_inset]) {
-        if ($stabilizer_type) support_for($stabilizers, $stabilizer_type);
+        if ($stabilizer_type != "disable") support_for($stabilizers, $stabilizer_type);
 
         // always render stem support even if there isn't a stem.
         // rendering flat support w/no stem is much more common than a hollow keycap
@@ -1494,47 +1554,35 @@ module key(inset = false) {
 // actual full key with space carved out and keystem/stabilizer connectors
 // this is an example key with all the fixins from settings.scad
 module example_key(){
-/* [Key] */
+/* [Basic-Settings] */
 
-//length in units of key
+// what type of stem you want. Most people want Cherry.
+$stem_type = "cherry";  // [cherry, alps, rounded_cherry, filled, disable]
+
+// support type. default is "flared" for easy FDM printing. to disable pass false
+$support_type = "flared"; // [flared, bars, flat, disable]
+
+//length in units of key. A regular key is 1 unit; spacebar is usually 6.25
 $key_length = 1;
-//height in units of key. should remain 1 for most uses
-$key_height = 1;
-
-/* [Brim] */
 
 //print brim for connector to help with bed adhesion
 $has_brim = false;
-// how tall in mm the brim is, if there is one. brim sits around the keystem and helps to secure it while printing.
-$brim_height = 0.4;
-// what type of stem you want. To turn off stems pass false. "cherry", "alps", and "cherry_rounded" supported
 
-/* [Stem] */
-// What stem do you want to use?
-$stem_type = "cherry";  // [cherry, alps, rounded_cherry, filled]
-// how much higher the stem is than the bottom of the keycap.
-// inset stem requires support but is more accurate in some profiles
-$stem_inset = 0;
-// how many degrees to rotate the stems. useful for sideways keycaps, maybe
-$stem_rotation = 0;
 // the stem is the hardest part to print, so this variable controls how much 'slop' there is in the stem
 $stem_slop = 0.3;
-
-/* [Support] */
-
-// support type. default is "flared" for easy FDM printing. to disable pass false
-$support_type = "flared"; // [flared, bars, flat]
-
-/* [Misc] */
 
 // font size used for text
 $font_size = 6;
 
+// invert dishing. mostly for spacebar
+$inverted_dish = false;
 
-/* [Advanced Features] */
+
+/* [Advanced] */
 
 /* Key */
-
+// height in units of key. should remain 1 for most uses
+$key_height = 1;
 // keytop thickness, aka how many millimeters between the inside and outside of the top surface of the key
 $keytop_thickness = 1;
 // wall thickness, aka the thickness of the sides of the keycap. note this is the total thickness, aka 3 = 1.5mm walls
@@ -1567,6 +1615,12 @@ $rounded_cherry_stem_d = 5.5;
 // dimensions of alps stem
 $alps_stem = [4.45, 2.25];
 
+// how much higher the stem is than the bottom of the keycap.
+// inset stem requires support but is more accurate in some profiles
+$stem_inset = 0;
+// how many degrees to rotate the stems. useful for sideways keycaps, maybe
+$stem_rotation = 0;
+
 /* Stabilizers */
 
 // array of positions of stabilizers
@@ -1588,15 +1642,13 @@ $height_slices = 1;
 /* Dish */
 
 // what type of dish the key has. note that unlike stems and supports a dish ALWAYS gets rendered.
-$dish_type = "cylindrical"; // [cylindrical, spherical, sideways cylindrical, old spherical]
+$dish_type = "cylindrical"; // [cylindrical, spherical, sideways cylindrical, old spherical, disable]
 // how deep the dish 'digs' into the top of the keycap. this is max depth, so you can't find the height from total_depth - dish_depth. besides the top is skewed anyways
 $dish_depth = 1;
 // how skewed in the x direction the dish is
 $dish_skew_x = 0;
 // how skewed in the y direction (height) the dish is
 $dish_skew_y = 0;
-// invert dishing. mostly for spacebar
-$inverted_dish = false;
 // if you need the dish to extend further, you can 'overdraw' the rectangle it will hit
 $dish_overdraw_width = 0;
 // same as width but for height
@@ -1604,6 +1656,8 @@ $dish_overdraw_height = 0;
 
 /* Misc */
 
+// how tall in mm the brim is, if there is one. brim sits around the keystem and helps to secure it while printing.
+$brim_height = 0.4;
 // font used for text
 $font="DejaVu Sans Mono:style=Book";
 // whether or not to render fake keyswitches to check clearances
@@ -1632,4 +1686,4 @@ $key_bump_edge = 0.4;
 }
 
 
-key();
+key_profile(key_profile, row) legend(legend) key();

--- a/key/customizer.scad
+++ b/key/customizer.scad
@@ -13,28 +13,27 @@ legend = "";
 
 /* [Basic-Settings] */
 
-// What type of stem you want. Most people want Cherry.
-$stem_type = "cherry";  // [cherry, alps, rounded_cherry, box_cherry, filled, disable]
-
-// Support type. default is "flared" for easy FDM printing; bars are more realistic, and flat could be for artisans
-$support_type = "flared"; // [flared, bars, flat, disable]
-
 // Length in units of key. A regular key is 1 unit; spacebar is usually 6.25
 $key_length = 1.0; // Range not working in thingiverse customizer atm [1:0.25:16]
 
-// Supports for the stem, as it often comes off during printing. disabled by default, but highly reccommended.
-$stem_support_type = "disable"; // [brim, tines, disabled]
+// What type of stem you want. Most people want Cherry.
+$stem_type = "cherry";  // [cherry, alps, rounded_cherry, box_cherry, filled, disable]
+
 // The stem is the hardest part to print, so this variable controls how much 'slop' there is in the stem
 $stem_slop = 0.3; // Not working in thingiverse customizer atm [0:0.01:1]
 
 // Font size used for text
 $font_size = 6;
 
-// Invert dishing. mostly for spacebar
+// Set this to true if you're making a spacebar!
 $inverted_dish = false;
 
-// Enable stabilizers. If you don't want stabilizers use disable; most other keycaps use Cherry stabilizers
-$stabilizer_type = "disable"; // [cherry, rounded_cherry, alps, disable]
+
+// Support type. default is "flared" for easy FDM printing; bars are more realistic, and flat could be for artisans
+$support_type = "flared"; // [flared, bars, flat, disable]
+
+// Supports for the stem, as it often comes off during printing. disabled by default, but highly reccommended.
+$stem_support_type = "disable"; // [tines, brim, disabled]
 
 /* [Advanced] */
 
@@ -139,11 +138,14 @@ $legends = [];
 // Dimensions of alps stem
 $alps_stem = [4.45, 2.25];
 
-// Ternary is ONLY for customizer. it will NOT work if you're using this in
-// OpenSCAD, unless you're using the customizer. you should use stabilized() or
-// Set the variable directly
+// Enable stabilizers. If you don't want stabilizers use disable; most other keycaps use Cherry stabilizers
+$stabilizer_type = "cherry"; // [cherry, rounded_cherry, alps, disable]
+
+// Ternaries are ONLY for customizer. they will NOT work if you're using this in
+// OpenSCAD. you should use stabilized(), openSCAD customizer,
+// or set $stabilizers directly
 // Array of positions of stabilizers
-$stabilizers = $key_length > 5.75 ? [[-50, 0], [50, 0]] : [[-12,0],[12,0]];
+$stabilizers = $key_length >= 6 ? [[-50, 0], [50, 0]] : $key_length >= 2 ? [[-12,0],[12,0]] : [];
 
 // Where the stems are in relation to the center of the keycap, in units. default is one in the center
 // Shouldn't work in thingiverse customizer, though it has been...
@@ -2071,28 +2073,27 @@ module key(inset = false) {
 module example_key(){
 /* [Basic-Settings] */
 
-// What type of stem you want. Most people want Cherry.
-$stem_type = "cherry";  // [cherry, alps, rounded_cherry, box_cherry, filled, disable]
-
-// Support type. default is "flared" for easy FDM printing; bars are more realistic, and flat could be for artisans
-$support_type = "flared"; // [flared, bars, flat, disable]
-
 // Length in units of key. A regular key is 1 unit; spacebar is usually 6.25
 $key_length = 1.0; // Range not working in thingiverse customizer atm [1:0.25:16]
 
-// Supports for the stem, as it often comes off during printing. disabled by default, but highly reccommended.
-$stem_support_type = "disable"; // [brim, tines, disabled]
+// What type of stem you want. Most people want Cherry.
+$stem_type = "cherry";  // [cherry, alps, rounded_cherry, box_cherry, filled, disable]
+
 // The stem is the hardest part to print, so this variable controls how much 'slop' there is in the stem
 $stem_slop = 0.3; // Not working in thingiverse customizer atm [0:0.01:1]
 
 // Font size used for text
 $font_size = 6;
 
-// Invert dishing. mostly for spacebar
+// Set this to true if you're making a spacebar!
 $inverted_dish = false;
 
-// Enable stabilizers. If you don't want stabilizers use disable; most other keycaps use Cherry stabilizers
-$stabilizer_type = "disable"; // [cherry, rounded_cherry, alps, disable]
+
+// Support type. default is "flared" for easy FDM printing; bars are more realistic, and flat could be for artisans
+$support_type = "flared"; // [flared, bars, flat, disable]
+
+// Supports for the stem, as it often comes off during printing. disabled by default, but highly reccommended.
+$stem_support_type = "disable"; // [tines, brim, disabled]
 
 /* [Advanced] */
 
@@ -2197,11 +2198,14 @@ $legends = [];
 // Dimensions of alps stem
 $alps_stem = [4.45, 2.25];
 
-// Ternary is ONLY for customizer. it will NOT work if you're using this in
-// OpenSCAD, unless you're using the customizer. you should use stabilized() or
-// Set the variable directly
+// Enable stabilizers. If you don't want stabilizers use disable; most other keycaps use Cherry stabilizers
+$stabilizer_type = "cherry"; // [cherry, rounded_cherry, alps, disable]
+
+// Ternaries are ONLY for customizer. they will NOT work if you're using this in
+// OpenSCAD. you should use stabilized(), openSCAD customizer,
+// or set $stabilizers directly
 // Array of positions of stabilizers
-$stabilizers = $key_length > 5.75 ? [[-50, 0], [50, 0]] : [[-12,0],[12,0]];
+$stabilizers = $key_length >= 6 ? [[-50, 0], [50, 0]] : $key_length >= 2 ? [[-12,0],[12,0]] : [];
 
 // Where the stems are in relation to the center of the keycap, in units. default is one in the center
 // Shouldn't work in thingiverse customizer, though it has been...

--- a/key/customizer.scad
+++ b/key/customizer.scad
@@ -16,17 +16,17 @@ legend = "";
 // what type of stem you want. Most people want Cherry.
 $stem_type = "cherry";  // [cherry, alps, rounded_cherry, filled, disable]
 
-// support type. default is "flared" for easy FDM printing. to disable pass false
+// support type. default is "flared" for easy FDM printing; bars are more realistic, and flat could be for artisans
 $support_type = "flared"; // [flared, bars, flat, disable]
 
-//length in units of key. A regular key is 1 unit; spacebar is usually 6.25
-$key_length = 1;
+// length in units of key. A regular key is 1 unit; spacebar is usually 6.25
+$key_length = 1.0; // range not working in thingiverse customizer atm [1:0.25:16]
 
-//print brim for connector to help with bed adhesion
+// print brim for connector to help with bed adhesion
 $has_brim = false;
 
 // the stem is the hardest part to print, so this variable controls how much 'slop' there is in the stem
-$stem_slop = 0.3;
+$stem_slop = 0.3; // not working in thingiverse customizer atm [0:0.01:1]
 
 // font size used for text
 $font_size = 6;
@@ -34,12 +34,14 @@ $font_size = 6;
 // invert dishing. mostly for spacebar
 $inverted_dish = false;
 
+// Enable stabilizers. If you don't want stabilizers use disable; most other keycaps use Cherry stabilizers
+$stabilizer_type = "disable"; // [cherry, rounded_cherry, alps, disable]
 
 /* [Advanced] */
 
 /* Key */
 // height in units of key. should remain 1 for most uses
-$key_height = 1;
+$key_height = 1.0;
 // keytop thickness, aka how many millimeters between the inside and outside of the top surface of the key
 $keytop_thickness = 1;
 // wall thickness, aka the thickness of the sides of the keycap. note this is the total thickness, aka 3 = 1.5mm walls
@@ -80,11 +82,11 @@ $stem_rotation = 0;
 
 /* Stabilizers */
 
+// ternary is ONLY for customizer. it will NOT work if you're using this in
+// openSCAD, unless you're using the customizer. you should use stabilized() or
+// set the variable directly
 // array of positions of stabilizers
-$stabilizers = [[-50,0],[50,0]];
-// what type of stem you want for the stabilizers. false disables
-$stabilizer_type = false;
-
+$stabilizers = $key_length > 5.75 ? [[-50, 0], [50, 0]] : [[-12,0],[12,0]];
 
 /* Shape */
 
@@ -762,7 +764,7 @@ function cherry_cross(slop) = [
   // horizontal tine
   [4.03 + slop, 1.15 + slop / 3],
   // vertical tine
-  [1.25 + slop / 3, 5.5 - slop * 2 + .005],
+  [1.25 + slop / 3, 4.9 + slop / 3 + .005],
 ];
 
 module cherry_stem(depth, has_brim, slop) {
@@ -804,8 +806,8 @@ module cherry_stem(depth, has_brim, slop) {
 function cherry_cross(slop) = [
   // horizontal tine
   [4.03 + slop, 1.15 + slop / 3],
-  // vertical tine
-  [1.25 + slop / 3, 5.5 - slop * 2 + .005],
+  // vertical tine. can't really afford much slop
+  [1.25 + slop / 3, 4.9 + slop / 6 + .005],
 ];
 
 module rounded_cherry_stem(depth, has_brim, slop) {
@@ -1559,17 +1561,17 @@ module example_key(){
 // what type of stem you want. Most people want Cherry.
 $stem_type = "cherry";  // [cherry, alps, rounded_cherry, filled, disable]
 
-// support type. default is "flared" for easy FDM printing. to disable pass false
+// support type. default is "flared" for easy FDM printing; bars are more realistic, and flat could be for artisans
 $support_type = "flared"; // [flared, bars, flat, disable]
 
-//length in units of key. A regular key is 1 unit; spacebar is usually 6.25
-$key_length = 1;
+// length in units of key. A regular key is 1 unit; spacebar is usually 6.25
+$key_length = 1.0; // range not working in thingiverse customizer atm [1:0.25:16]
 
-//print brim for connector to help with bed adhesion
+// print brim for connector to help with bed adhesion
 $has_brim = false;
 
 // the stem is the hardest part to print, so this variable controls how much 'slop' there is in the stem
-$stem_slop = 0.3;
+$stem_slop = 0.3; // not working in thingiverse customizer atm [0:0.01:1]
 
 // font size used for text
 $font_size = 6;
@@ -1577,12 +1579,14 @@ $font_size = 6;
 // invert dishing. mostly for spacebar
 $inverted_dish = false;
 
+// Enable stabilizers. If you don't want stabilizers use disable; most other keycaps use Cherry stabilizers
+$stabilizer_type = "disable"; // [cherry, rounded_cherry, alps, disable]
 
 /* [Advanced] */
 
 /* Key */
 // height in units of key. should remain 1 for most uses
-$key_height = 1;
+$key_height = 1.0;
 // keytop thickness, aka how many millimeters between the inside and outside of the top surface of the key
 $keytop_thickness = 1;
 // wall thickness, aka the thickness of the sides of the keycap. note this is the total thickness, aka 3 = 1.5mm walls
@@ -1623,11 +1627,11 @@ $stem_rotation = 0;
 
 /* Stabilizers */
 
+// ternary is ONLY for customizer. it will NOT work if you're using this in
+// openSCAD, unless you're using the customizer. you should use stabilized() or
+// set the variable directly
 // array of positions of stabilizers
-$stabilizers = [[-50,0],[50,0]];
-// what type of stem you want for the stabilizers. false disables
-$stabilizer_type = false;
-
+$stabilizers = $key_length > 5.75 ? [[-50, 0], [50, 0]] : [[-12,0],[12,0]];
 
 /* Shape */
 

--- a/key/customizer.scad
+++ b/key/customizer.scad
@@ -116,7 +116,7 @@ $dish_overdraw_height = 0;
 /* Misc */
 
 // how tall in mm the brim is, if there is one. brim sits around the keystem and helps to secure it while printing.
-$brim_height = 0.4;
+$stem_support_height = 0.4;
 // font used for text
 $font="DejaVu Sans Mono:style=Book";
 // whether or not to render fake keyswitches to check clearances
@@ -492,7 +492,7 @@ module translate_u(x=0, y=0, z=0){
 
 module brimmed(height = 0.2) {
   $has_brim = true;
-  $brim_height = height;
+  $stem_support_height = height;
   children();
 }
 
@@ -779,7 +779,7 @@ module cherry_stem(depth, has_brim, slop) {
 
       // brim, if applicable
       if(has_brim) {
-        linear_extrude(height = $brim_height){
+        linear_extrude(height = $stem_support_height){
           offset(r=1){
             square(outer_cherry_stem(slop) + [2,2], center=true);
           }
@@ -815,7 +815,7 @@ module rounded_cherry_stem(depth, has_brim, slop) {
     union(){
       cylinder(d=$rounded_cherry_stem_d, h=depth);
       if(has_brim) {
-        cylinder(d=$rounded_cherry_stem_d * 2, h=$brim_height);
+        cylinder(d=$rounded_cherry_stem_d * 2, h=$stem_support_height);
       }
     }
 
@@ -831,7 +831,7 @@ module rounded_cherry_stem(depth, has_brim, slop) {
 }
 module alps_stem(depth, has_brim, slop){
   if(has_brim) {
-    linear_extrude(height=$brim_height) {
+    linear_extrude(height=$stem_support_height) {
       offset(r=1){
         square($alps_stem + [2,2], center=true);
       }
@@ -1661,7 +1661,7 @@ $dish_overdraw_height = 0;
 /* Misc */
 
 // how tall in mm the brim is, if there is one. brim sits around the keystem and helps to secure it while printing.
-$brim_height = 0.4;
+$stem_support_height = 0.4;
 // font used for text
 $font="DejaVu Sans Mono:style=Book";
 // whether or not to render fake keyswitches to check clearances

--- a/key/customizer.scad
+++ b/key/customizer.scad
@@ -1,122 +1,547 @@
-/*
-  Hello there!
-  if you're seeing this, you're probably poking at the Customizer script, wondering how it all works. I would HIGHLY recommend you look at the zip file or github instead! Thingiverse does not support including openSCAD files into other openSCAD files, so I had to copy / paste all my separated code into a single file :/ that's why this is over a thousand lines long! it's much more readable when it's all separate, trust me.
+// the point of this file is to be a sort of DSL for constructing keycaps.
+// when you create a method chain you are just changing the parameters
+// key.scad uses, it doesn't generate anything itself until the end. This
+// lets it remain easy to use key.scad like before (except without key profiles)
+// without having to rely on this file. Unfortunately that means setting tons of
+// special variables, but that's a limitation of SCAD we have to work around
 
-  Or don't, I'm just a comment
- */
+// files
+$fs=.1;
+unit = 19.05;
 
-/* [Hidden] */
+// corollary is rounded_square
+// NOT 3D
+module ISO_enter_shape(size, delta, progress){
+  width = size[0];
+  height = size[1];
+  function unit_length(length) = unit * (length - 1) + 18.16;
 
-// BEGIN SETTINGS
 
-// keytop thickness, aka how many millimeters between the inside and outside of the top surface of the key
-$keytop_thickness = 1;
-// wall thickness, aka the thickness of the sides of the keycap. note this is the total thickness, aka 3 = 1.5mm walls
-$wall_thickness = 3;
-//whether stabilizer connectors are enabled
-$stabilizers = false;
-// font used for text
-$font="DejaVu Sans Mono:style=Book";
-// font size used for text
-$font_size = 6;
-// whether or not to render fake keyswitches to check clearances
-$clearance_check = false;
+  // in order to make the ISO keycap shape generic, we are going to express the
+  // 'elbow point' in terms of ratios. an ISO enter is just a 1.5u key stuck on
+  // top of a 1.25u key, but since our key_shape function doesnt understand that
+  // and wants to pass just width and height, we make these ratios to know where
+  // to put the elbow joint
 
-/* [Key profile] */
+  width_ratio = unit_length(1.25) / unit_length(1.5);
+  height_ratio = unit_length(1) / unit_length(2);
 
-// width of the very bottom of the key
-$bottom_key_width = 18.16;
-// height (from the front) of the very bottom of the ke
-$bottom_key_height = 18.16;
-// how much less width there is on the top. eg top_key_width = bottom_key_width - width_difference
-$width_difference = 6;
-// how much less height there is on the top
-$height_difference = 4;
-// how deep the key is, before adding a dish
-$total_depth = 11.5;
-// the tilt of the dish in degrees. divided by key height
-$top_tilt = -6;
-// how skewed towards the back the top is (0 for center)
-$top_skew = 1.7;
-// what type of dish the key has. note that unlike stems and supports a dish ALWAYS gets rendered.
-$dish_type = "cylindrical";
-// how deep the dish 'digs' into the top of the keycap. this is max depth, so you can't find the height from total_depth - dish_depth. besides the top is skewed anyways
-$dish_depth = 1;
-// how skewed in the x direction the dish is
-$dish_skew_x = 0;
-// how skewed in the y direction (height) the dish is
-$dish_skew_y = 0;
-//length in units of key
-$key_length = 1;
-//height in units of key. should remain 1 for most uses
-$key_height = 1;
-//print brim for connector to help with bed adhesion
-$has_brim = false;
-// invert dishing. mostly for spacebar
-$inverted_dish = false;
-// array of positions of all stems. includes stabilizers as well, for now
-// ternary is a bad hack to keep the stabilizers flag working
-$connectors = $stabilizers ? [[0,0],[-50,0],[50,0]] : [[0,0]];
-// use linear_extrude instead of hull slices to make the shape of the key
-// should be faster, also required for concave shapes
-$linear_extrude_shape = false;
-//should the key be rounded? unnecessary for most printers, and very slow
-$rounded_key = false;
-// what type of stem you want. To turn off stems pass false. "cherry", "alps", and "cherry_rounded" supported
-$stem_type = "cherry";
-// how much higher the stem is than the bottom of the keycap.
-// inset stem requires support but is more accurate in some profiles
-$stem_inset = 0;
-// how many degrees to rotate the stems. useful for sideways keycaps, maybe
-$stem_rotation = 0;
-// radius of corners of keycap
-$corner_radius = 1;
-// keystem slop - lengthens the cross and thins out the connector
-$stem_slop = 0.3;
-// support type. default is "flared" for easy FDM printing. to disable pass false
-$support_type = "flared";
-// key shape type, determines the shape of the key. default is 'rounded square'
-$key_shape_type = "rounded_square";
-// ISO enter needs to be linear extruded NOT from the center. this tells the program how far up 'not from the center' is
-$linear_extrude_height_adjustment = 0;
-// if you need the dish to extend further, you can 'overdraw' the rectangle it will hit
-$dish_overdraw_width = 0;
-// same as width but for height
-$dish_overdraw_height = 0;
-// how many slices will be made, to approximate curves on corners. Leave at 1 if you are not curving corners
-// if you're doing fancy bowed keycap sides, this controls how many slices you take
-$height_slices = 1;
-// this enables some fancy and currently hardcoded logic to bow the sides and corners of SA keycaps
-$enable_side_sculpting = false;
+  pointArray = [
+      [                   0,                     0], // top right
+      [                   0,               -height], // bottom right
+      [-width * width_ratio,               -height], // bottom left
+      [-width * width_ratio,-height * height_ratio], // inner middle point
+      [              -width,-height * height_ratio], // outer middle point
+      [              -width,                     0]  // top left
+  ];
 
-//minkowski radius. radius of sphere used in minkowski sum for minkowski_key function. 1.75 for G20
-$minkowski_radius = .33;
+  minkowski(){
+    circle(r=corner_size);
+    // gives us rounded inner corner
+    offset(r=-corner_size*2) {
+      translate([(width * width_ratio)/2, height/2]) polygon(points=pointArray);
+    }
+  }
+}
+// rounded square shape with additional sculpting functions to better approximate
 
-// the stem is the hardest part to print, so this variable controls how much 'slop' there is in the stem
-$stem_slop = 0.3;
+// When sculpting sides, how much in should the tops come
+$side_sculpting_factor = 4.5;
+// When sculpting corners, how much extra radius should be added
+$corner_sculpting_factor = 1;
+// When doing more side sculpting corners, how much extra radius should be added
+$more_side_sculpting_factor = 0.4;
 
-// how tall in mm the brim is, if there is one. brim sits around the keystem and helps to secure it while printing.
-$brim_height = 0.4;
-// how far the throw distance of the switch is. determines how far the 'cross' in the cherry switch digs into the stem, and how long the keystem needs to be before supports can start. luckily, alps and cherries have a pretty similar throw. can modify to have stouter keycaps for low profile switches, etc
-$stem_throw = 4;
 
+// side sculpting functions
+// bows the sides out on stuff like SA and DSA keycaps
+function side_sculpting(progress) = (1 - progress) * $side_sculpting_factor;
+// makes the rounded corners of the keycap grow larger as they move upwards
+function corner_sculpting(progress) = pow(progress, 2) * $corner_sculpting_factor;
+
+module sculpted_square_shape(size, delta, progress) {
+  width = size[0];
+  height = size[1];
+
+  width_difference = delta[0];
+  height_difference = delta[1];
+  // makes the sides bow
+  extra_side_size =  side_sculpting(progress);
+  // makes the rounded corners of the keycap grow larger as they move upwards
+  extra_corner_size = corner_sculpting(progress);
+
+  // computed values for this slice
+  extra_width_this_slice = (width_difference - extra_side_size) * progress;
+  extra_height_this_slice = (height_difference - extra_side_size) * progress;
+  extra_corner_radius_this_slice = ($corner_radius + extra_corner_size);
+
+  square_size = [
+    width - extra_width_this_slice,
+    height - extra_height_this_slice
+  ];
+
+  offset(r = extra_corner_radius_this_slice) {
+    offset(r = -extra_corner_radius_this_slice) {
+      side_rounded_square(square_size, r = $more_side_sculpting_factor * progress);
+    }
+  }
+}
+
+module side_rounded_square(size, r) {
+    iw = size.x - 2 * r;
+    ih = size.y - 2 * r;
+    resolution = 100;
+    sr = r / resolution * 2;
+    sh = ih / resolution;
+    sw = iw / resolution;
+    union() {
+        translate([-iw/2, 0]) scale([sr, sh]) circle(d = resolution);
+        translate([iw/2, 0]) scale([sr, sh]) circle(d = resolution);
+        translate([0, -ih/2]) scale([sw, sr]) circle(d = resolution);
+        translate([0, ih/2]) scale([sw, sr]) circle(d = resolution);
+        square([iw, ih], center=true);
+    }
+}
+module rounded_square_shape(size, delta, progress, center = true) {
+    width = size[0];
+    height = size[1];
+
+    width_difference = delta[0];
+    height_difference = delta[1];
+
+    // computed values for this slice
+    extra_width_this_slice = (width_difference) * progress;
+    extra_height_this_slice = (height_difference) * progress;
+    extra_corner_radius_this_slice = ($corner_radius);
+
+    offset(r=extra_corner_radius_this_slice){
+      square(
+        [
+          width - extra_width_this_slice - extra_corner_radius_this_slice * 2,
+          height - extra_height_this_slice - extra_corner_radius_this_slice * 2
+        ],
+        center=center
+      );
+    }
+}
+module square_shape(size, delta, progress){
+  square(size - delta * progress, center = true);
+}
+module oblong_shape(size, delta, progress) {
+  // .05 is because of offset. if we set offset to be half the height of the shape, and then subtract height from the shape, the height of the shape will be zero (because the shape would be [width - height, height - height]). that doesn't play well with openSCAD (understandably), so we add this tiny fudge factor to make sure the shape we offset has a positive width
+  height = size[1] - delta[1] * progress - .05;
+
+  if (progress < 0.5) {
+  } else {
+    offset(r=height / 2) {
+      square(size - [height, height] - delta * progress, center=true);
+    }
+  }
+}
+
+module key_shape(size, delta, progress = 0) {
+  if ($key_shape_type == "iso_enter") {
+    ISO_enter_shape(size, delta, progress);
+  } else if ($key_shape_type == "sculpted_square") {
+    sculpted_square_shape(size, delta, progress);
+  } else if ($key_shape_type == "rounded_square") {
+    rounded_square_shape(size, delta, progress);
+  } else if ($key_shape_type == "square") {
+    square_shape(size, delta, progress);
+  } else if ($key_shape_type == "oblong") {
+    oblong_shape(size, delta, progress);
+  } else {
+    echo("Warning: unsupported $key_shape_type");
+  }
+}
 // cherry stem dimensions
-$cherry_stem = [7.2 - $stem_slop * 2, 5.5 - $stem_slop * 2];
+function outer_cherry_stem(slop) = [7.2 - slop * 2, 5.5 - slop * 2];
 
 // .005 purely for aesthetics, to get rid of that ugly crosshatch
-$cherry_cross = [
+function cherry_cross(slop) = [
   // horizontal tine
-  [4.03 + $stem_slop, 1.15],
+  [4.03 + slop, 1.15 + slop / 3],
   // vertical tine
-  [1.25, $cherry_stem[1] + .005],
+  [1.25 + slop / 3, 5.5 - slop * 2 + .005],
 ];
 
-// diameter of the outside of the rounded cherry stem
-$rounded_cherry_stem_d = 5.5;
+module cherry_stem(depth, has_brim, slop) {
+  difference(){
+    union() {
+      // outside shape
+      linear_extrude(height = depth) {
+        offset(r=1){
+          square(outer_cherry_stem(slop) - [2,2], center=true);
+        }
+      }
 
-// dimensions of alps stem
-$alps_stem = [4.45, 2.25];
+      // brim, if applicable
+      if(has_brim) {
+        linear_extrude(height = $brim_height){
+          offset(r=1){
+            square(outer_cherry_stem(slop) + [2,2], center=true);
+          }
+        }
+      }
+    }
 
+    // inside cross
+    // translation purely for aesthetic purposes, to get rid of that awful lattice
+    translate([0,0,-0.005]) {
+      linear_extrude(height = $stem_throw) {
+        square(cherry_cross(slop)[0], center=true);
+        square(cherry_cross(slop)[1], center=true);
+      }
+      // Guides to assist insertion and mitigate first layer squishing
+      for (i = cherry_cross(slop)) hull() {
+        linear_extrude(height = 0.01, center = false) offset(delta = 0.4) square(i, center=true);
+        translate([0, 0, 0.5]) linear_extrude(height = 0.01, center = false)  square(i, center=true);
+      }
+    }
+  }
+}
+// .005 purely for aesthetics, to get rid of that ugly crosshatch
+function cherry_cross(slop) = [
+  // horizontal tine
+  [4.03 + slop, 1.15 + slop / 3],
+  // vertical tine
+  [1.25 + slop / 3, 5.5 - slop * 2 + .005],
+];
+
+module rounded_cherry_stem(depth, has_brim, slop) {
+  difference(){
+    union(){
+      cylinder(d=$rounded_cherry_stem_d, h=depth);
+      if(has_brim) {
+        cylinder(d=$rounded_cherry_stem_d * 2, h=$brim_height);
+      }
+    }
+
+    // inside cross
+    // translation purely for aesthetic purposes, to get rid of that awful lattice
+    translate([0,0,-0.005]) {
+      linear_extrude(height = $stem_throw) {
+        square(cherry_cross(slop)[0], center=true);
+        square(cherry_cross(slop)[1], center=true);
+      }
+    }
+  }
+}
+module alps_stem(depth, has_brim, slop){
+  if(has_brim) {
+    linear_extrude(height=$brim_height) {
+      offset(r=1){
+        square($alps_stem + [2,2], center=true);
+      }
+    }
+  }
+  linear_extrude(height=depth) {
+    square($alps_stem, center = true);
+  }
+}
+module filled_stem() {
+  // I broke the crap out of this stem type due to the changes I made around how stems are differenced
+  // now that we just take the dish out of stems in order to support stuff like
+  // bare stem keycaps (and buckling spring eventually) we can't just make a
+  // cube. shape() works but means that you certainly couldn't render this
+  // stem without the presence of the entire library
+
+  shape();
+}
+
+
+//whole stem, alps or cherry, trimmed to fit
+module stem(stem_type, depth, has_brim, slop){
+    if (stem_type == "alps") {
+      alps_stem(depth, has_brim, slop);
+    } else if (stem_type == "cherry_rounded") {
+      rounded_cherry_stem(depth, has_brim, slop);
+    } else if (stem_type == "cherry") {
+      cherry_stem(depth, has_brim, slop);
+    } else if (stem_type == "filled") {
+      filled_stem();
+    } else {
+      echo("Warning: unsupported $stem_type");
+    }
+}
+// from https://www.thingiverse.com/thing:1484333
+// public domain license
+// same syntax and semantics as built-in sphere, so should be a drop-in replacement
+// it's a bit slow for large numbers of facets
+module geodesic_sphere(r=-1, d=-1) {
+  // if neither parameter specified, radius is taken to be 1
+  rad = r > 0 ? r : d > 0 ? d/2 : 1;
+
+  pentside_pr = 2*sin(36);  // side length compared to radius of a pentagon
+  pentheight_pr = sqrt(pentside_pr*pentside_pr - 1);
+  // from center of sphere, icosahedron edge subtends this angle
+  edge_subtend = 2*atan(pentheight_pr);
+
+  // vertical rotation by 72 degrees
+  c72 = cos(72);
+  s72 = sin(72);
+  function zrot(pt) = [ c72*pt[0]-s72*pt[1], s72*pt[0]+c72*pt[1], pt[2] ];
+
+  // rotation from north to vertex along positive x
+  ces = cos(edge_subtend);
+  ses = sin(edge_subtend);
+  function yrot(pt) = [ ces*pt[0] + ses*pt[2], pt[1], ces*pt[2]-ses*pt[0] ];
+
+  // 12 icosahedron vertices generated from north, south, yrot and zrot
+  ic1 = [ 0, 0, 1 ];  // north
+  ic2 = yrot(ic1);    // north and +x
+  ic3 = zrot(ic2);    // north and +x and +y
+  ic4 = zrot(ic3);    // north and -x and +y
+  ic5 = zrot(ic4);    // north and -x and -y
+  ic6 = zrot(ic5);    // north and +x and -y
+  ic12 = [ 0, 0, -1]; // south
+  ic10 = yrot(ic12);  // south and -x
+  ic11 = zrot(ic10);  // south and -x and -y
+  ic7 = zrot(ic11);   // south and +x and -y
+  ic8 = zrot(ic7);    // south and +x and +y
+  ic9 = zrot(ic8);    // south and -x and +y
+
+  // start with icosahedron, icos[0] is vertices and icos[1] is faces
+  icos = [ [ic1, ic2, ic3, ic4, ic5, ic6, ic7, ic8, ic9, ic10, ic11, ic12 ],
+    [ [0, 2, 1], [0, 3, 2], [0, 4, 3], [0, 5, 4], [0, 1, 5],
+      [1, 2, 7], [2, 3, 8], [3, 4, 9], [4, 5, 10], [5, 1, 6],
+      [7, 6, 1], [8, 7, 2], [9, 8, 3], [10, 9, 4], [6, 10, 5],
+      [6, 7, 11], [7, 8, 11], [8, 9, 11], [9, 10, 11], [10, 6, 11]]];
+
+  // now for polyhedron subdivision functions
+
+  // given two 3D points on the unit sphere, find the half-way point on the great circle
+  // (euclidean midpoint renormalized to be 1 unit away from origin)
+  function midpt(p1, p2) =
+    let (midx = (p1[0] + p2[0])/2, midy = (p1[1] + p2[1])/2, midz = (p1[2] + p2[2])/2)
+    let (midlen = sqrt(midx*midx + midy*midy + midz*midz))
+    [ midx/midlen, midy/midlen, midz/midlen ];
+
+  // given a "struct" where pf[0] is vertices and pf[1] is faces, subdivide all faces into
+  // 4 faces by dividing each edge in half along a great circle (midpt function)
+  // and returns a struct of the same format, i.e. pf[0] is a (larger) list of vertices and
+  // pf[1] is a larger list of faces.
+  function subdivpf(pf) =
+    let (p=pf[0], faces=pf[1])
+    [ // for each face, barf out six points
+      [ for (f=faces)
+          let (p0 = p[f[0]], p1 = p[f[1]], p2=p[f[2]])
+            // "identity" for-loop saves having to flatten
+            for (outp=[ p0, p1, p2, midpt(p0, p1), midpt(p1, p2), midpt(p0, p2) ]) outp
+      ],
+      // now, again for each face, spit out four faces that connect those six points
+      [ for (i=[0:len(faces)-1])
+        let (base = 6*i)  // points generated in multiples of 6
+          for (outf =
+          [[ base, base+3, base+5],
+          [base+3, base+1, base+4],
+          [base+5, base+4, base+2],
+          [base+3, base+4, base+5]]) outf  // "identity" for-loop saves having to flatten
+      ]
+    ];
+
+  // recursive wrapper for subdivpf that subdivides "levels" times
+  function multi_subdiv_pf(pf, levels) =
+    levels == 0 ? pf :
+    multi_subdiv_pf(subdivpf(pf), levels-1);
+
+  // subdivision level based on $fa:
+  // level 0 has edge angle of edge_subtend so subdivision factor should be edge_subtend/$fa
+  // must round up to next power of 2.
+  // Take log base 2 of angle ratio and round up to next integer
+  ang_levels = ceil(log(edge_subtend/$fa)/log(2));
+
+  // subdivision level based on $fs:
+  // icosahedron edge length is rad*2*tan(edge_subtend/2)
+  // actually a chord and not circumference but let's say it's close enough
+  // subdivision factor should be rad*2*tan(edge_subtend/2)/$fs
+  side_levels = ceil(log(rad*2*tan(edge_subtend/2)/$fs)/log(2));
+
+  // subdivision level based on $fn: (fragments around circumference, not total facets)
+  // icosahedron circumference around equator is about 5 (level 1 is exactly 10)
+  // ratio of requested to equatorial segments is $fn/5
+  // level of subdivison is log base 2 of $fn/5
+  // round up to the next whole level so we get at least $fn
+  facet_levels = ceil(log($fn/5)/log(2));
+
+  // $fn takes precedence, otherwise facet_levels is NaN (-inf) but it's ok
+  // because it falls back to $fa or $fs, whichever translates to fewer levels
+  levels = $fn ? facet_levels : min(ang_levels, side_levels);
+
+  // subdivide icosahedron by these levels
+  subdiv_icos = multi_subdiv_pf(icos, levels);
+
+  scale(rad)
+  polyhedron(points=subdiv_icos[0], faces=subdiv_icos[1]);
+}
+
+module cylindrical_dish(width, height, depth, inverted){
+  // .5 has problems starting around 3u
+  $fa=.25;
+  /* we do some funky math here
+   * basically you want to have the dish "dig in" to the keycap x millimeters
+   * in order to do that you have to solve a small (2d) system of equations
+   * where the chord of the spherical cross section of the dish is
+   * the width of the keycap.
+   */
+  // the distance you have to move the dish so it digs in depth millimeters
+  chord_length = (pow(width, 2) - 4 * pow(depth, 2)) / (8 * depth);
+  //the radius of the dish
+  rad = (pow(width, 2) + 4 * pow(depth, 2)) / (8 * depth);
+  direction = inverted ? -1 : 1;
+
+  translate([0,0, chord_length * direction]){
+    rotate([90, 0, 0]) cylinder(h=height + 20, r=rad, center=true);
+  }
+}
+//the older, 'more accurate', and MUCH slower spherical dish.
+// generates the largest sphere possible that still contains the chord we are looking for
+// much more graduated curvature at an immense cost
+module old_spherical_dish(width, height, depth, inverted){
+
+  //same thing as the cylindrical dish here, but we need the corners to just touch - so we have to find the hypotenuse of the top
+  chord = pow((pow(width,2) + pow(height, 2)),0.5); //getting diagonal of the top
+
+  // the distance you have to move the dish up so it digs in depth millimeters
+  chord_length = (pow(chord, 2) - 4 * pow(depth, 2)) / (8 * depth);
+  //the radius of the dish
+  rad = (pow(chord, 2) + 4 * pow(depth, 2)) / (8 * depth);
+  direction = inverted ? -1 : 1;
+
+  translate([0,0,chord_length * direction]){
+    if (geodesic){
+      $fa=7;
+      geodesic_sphere(r=rad);
+    } else {
+      $fa=1;
+      // rotate 1 because the bottom of the sphere looks like trash
+      sphere(r=rad);
+    }
+  }
+}
+module sideways_cylindrical_dish(width, height, depth, inverted){
+  $fa=1;
+  chord_length = (pow(height, 2) - 4 * pow(depth, 2)) / (8 * depth);
+  rad = (pow(height, 2) + 4 * pow(depth, 2)) / (8 * depth);
+
+  direction = inverted ? -1 : 1;
+
+  translate([0,0, chord_length * direction]){
+    // cylinder is rendered facing up, so we rotate it on the y axis first
+    rotate([0,90,0]) cylinder(h = width + 20,r=rad, center=true); // +20 for fudge factor
+  }
+}
+module spherical_dish(width, height, depth, inverted){
+
+  //same thing as the cylindrical dish here, but we need the corners to just touch - so we have to find the hypotenuse of the top
+  chord = pow((pow(width,2) + pow(height, 2)),0.5); //getting diagonal of the top
+
+  // the distance you have to move the dish up so it digs in depth millimeters
+  chord_length = (pow(chord, 2) - 4 * pow(depth, 2)) / (8 * depth);
+  //the radius of the dish
+  rad = (pow(chord, 2) + 4 * pow(depth, 2)) / (8 * depth);
+  direction = inverted ? -1 : 1;
+
+  translate([0,0,0 * direction]){
+    if (geodesic){
+      $fa=20;
+      scale([chord/2/depth, chord/2/depth]) {
+        geodesic_sphere(r=depth);
+      }
+    } else {
+      $fa=6.5;
+      // rotate 1 because the bottom of the sphere looks like trash.
+      scale([chord/2/depth, chord/2/depth]) {
+        sphere(r=depth);
+      }
+    }
+  }
+}
+
+//geodesic looks much better, but runs very slow for anything above a 2u
+geodesic=false;
+
+//dish selector
+module  dish(width, height, depth, inverted) {
+    if($dish_type == "cylindrical"){
+      cylindrical_dish(width, height, depth, inverted);
+    }
+    else if ($dish_type == "spherical") {
+      spherical_dish(width, height, depth, inverted);
+    }
+    else if ($dish_type == "sideways cylindrical"){
+      sideways_cylindrical_dish(width, height, depth, inverted);
+    }
+    else if ($dish_type == "old spherical") {
+      old_spherical_dish(width, height, depth, inverted);
+    } else {
+      // else no dish, "no dish" is the value
+      // switchted to actually diffing a cube here due to changes to stems being differenced from the dish instead of the inside
+      translate([0,0,500]) cube([width, height, 1000], center=true);
+    }
+}
+// cherry stem dimensions
+// don't wanna introduce slop here so $stem_slop it is I guess
+function outer_cherry_stem() = [7.2 - $stem_slop * 2, 5.5 - $stem_slop * 2];
+
+// figures out the scale factor needed to make a 45 degree wall
+function scale_for_45(height, starting_size) = (height * 2 + starting_size) / starting_size;
+
+// complicated since we want the different stems to work well
+// also kind of messy... oh well
+module flared(stem_type, loft, height) {
+  translate([0,0,loft]){
+    if (stem_type == "cherry_rounded") {
+      linear_extrude(height=height, scale = scale_for_45(height, $rounded_cherry_stem_d)){
+        circle(d=$rounded_cherry_stem_d);
+      }
+    } else if (stem_type == "alps") {
+      alps_scale = [scale_for_45(height, $alps_stem[0]), scale_for_45(height, $alps_stem[1])];
+      linear_extrude(height=height, scale = alps_scale){
+        square($alps_stem, center=true);
+      }
+    } else {
+      // always render cherry if no stem type. this includes stem_type = false!
+      // this avoids a bug where the keycap is rendered filled when not desired
+      cherry_scale = [scale_for_45(height, outer_cherry_stem()[0]), scale_for_45(height, outer_cherry_stem()[1])];
+      linear_extrude(height=height, scale = cherry_scale){
+        offset(r=1){
+          square(outer_cherry_stem() - [2,2], center=true);
+        }
+      }
+    }
+  }
+}
+module flat(stem_type, loft, height) {
+  translate([0,0,loft + 500]){
+    cube(1000, center=true);
+  }
+}
+module bars(stem_type, loft, height) {
+  translate([0,0,loft + height / 2]){
+    cube([2, 100, height], center = true);
+    cube([100, 2, height], center = true);
+  }
+}
+
+module supports(type, stem_type, loft, height) {
+  if (type == "flared") {
+    flared(stem_type, loft, height);
+  } else if (type == "flat") {
+    flat(stem_type, loft, height);
+  } else if (type == "bars") {
+    bars(stem_type, loft, height);
+  } else {
+    echo("Warning: unsupported $support_type");
+  }
+}
+module keybump(depth = 0, edge_inset=0.4) {
+  radius = 0.5;
+  translate([0, -top_total_key_height()/2 + edge_inset, depth]){
+        rotate([90,0,90]) cylinder($font_size, radius, radius, true);
+        translate([0,0,-radius]) cube([$font_size, radius*2, radius*2], true);
+  }
+}
 
 // from https://www.thingiverse.com/thing:1484333
 // public domain license
@@ -229,364 +654,15 @@ module geodesic_sphere(r=-1, d=-1) {
   polyhedron(points=subdiv_icos[0], faces=subdiv_icos[1]);
 }
 
-// files
-$fs=.1;
-unit = 19.05;
 
-// corollary is rounded_square
-// NOT 3D
-module ISO_enter_shape(size, delta, progress){
-  width = size[0];
-  height = size[1];
-  function unit_length(length) = unit * (length - 1) + 18.16;
-
-
-  // in order to make the ISO keycap shape generic, we are going to express the
-  // 'elbow point' in terms of ratios. an ISO enter is just a 1.5u key stuck on
-  // top of a 1.25u key, but since our key_shape function doesnt understand that
-  // and wants to pass just width and height, we make these ratios to know where
-  // to put the elbow joint
-
-  width_ratio = unit_length(1.25) / unit_length(1.5);
-  height_ratio = unit_length(1) / unit_length(2);
-
-  pointArray = [
-      [                   0,                     0], // top right
-      [                   0,               -height], // bottom right
-      [-width * width_ratio,               -height], // bottom left
-      [-width * width_ratio,-height * height_ratio], // inner middle point
-      [              -width,-height * height_ratio], // outer middle point
-      [              -width,                     0]  // top left
-  ];
-
-  minkowski(){
-    circle(r=corner_size);
-    // gives us rounded inner corner
-    offset(r=-corner_size*2) {
-      translate([(width * width_ratio)/2, height/2]) polygon(points=pointArray);
-    }
-  }
-}
-
-// side sculpting functions
-// bows the sides out on stuff like SA and DSA keycaps
-function side_sculpting(progress) = (1 - progress) * 2.5;
-// makes the rounded corners of the keycap grow larger as they move upwards
-function corner_sculpting(progress) = pow(progress, 2);
-
-module rounded_square_shape(size, delta, progress, center = true) {
-    width = size[0];
-    height = size[1];
-
-    width_difference = delta[0];
-    height_difference = delta[1];
-    // makes the sides bow
-    extra_side_size =  $enable_side_sculpting ? side_sculpting(progress) : 0;
-    // makes the rounded corners of the keycap grow larger as they move upwards
-    extra_corner_size = $enable_side_sculpting ? corner_sculpting(progress) : 0;
-
-    // computed values for this slice
-    extra_width_this_slice = (width_difference - extra_side_size) * progress;
-    extra_height_this_slice = (height_difference - extra_side_size) * progress;
-    extra_corner_radius_this_slice = ($corner_radius + extra_corner_size);
-
-    offset(r=extra_corner_radius_this_slice){
-      square(
-        [
-          width - extra_width_this_slice - extra_corner_radius_this_slice * 2,
-          height - extra_height_this_slice - extra_corner_radius_this_slice * 2
-        ],
-        center=center
-      );
-    }
-}
-
-
-module square_shape(size, delta, progress){
-  square(size - delta * progress, center = true);
-}
-
-
-module oblong_shape(size, delta, progress) {
-  // .05 is because of offset. if we set offset to be half the height of the shape, and then subtract height from the shape, the height of the shape will be zero (because the shape would be [width - height, height - height]). that doesn't play well with openSCAD (understandably), so we add this tiny fudge factor to make sure the shape we offset has a positive width
-  height = size[1] - delta[1] * progress - .05;
-
-  if (progress < 0.5) {
-  } else {
-    offset(r=height / 2) {
-      square(size - [height, height] - delta * progress, center=true);
-    }
-  }
-}
-
-
-module key_shape(size, delta, progress = 0) {
-  if ($key_shape_type == "iso_enter") {
-    ISO_enter_shape(size, delta, progress);
-  } else if ($key_shape_type == "rounded_square") {
-    rounded_square_shape(size, delta, progress);
-  } else if ($key_shape_type == "square") {
-    square_shape(size, delta, progress);
-  } else if ($key_shape_type == "oblong") {
-    oblong_shape(size, delta, progress);
-  } else {
-    echo("Warning: unsupported $key_shape_type");
-  }
-}
-
-module cherry_stem(depth, has_brim) {
-  difference(){
-    union() {
-      // outside shape
-      linear_extrude(height = depth) {
-        offset(r=1){
-          square($cherry_stem - [2,2], center=true);
-        }
-      }
-
-      // brim, if applicable
-      if(has_brim) {
-        linear_extrude(height = brim_height){
-          offset(r=1){
-            square($cherry_stem - [2,2], center=true);
-          }
-        }
-      }
-    }
-
-    // inside cross
-    // translation purely for aesthetic purposes, to get rid of that awful lattice
-    translate([0,0,-0.005]) {
-      linear_extrude(height = $stem_throw) {
-        square($cherry_cross[0], center=true);
-        square($cherry_cross[1], center=true);
-      }
-    }
-  }
-}
-
-module rounded_cherry_stem(depth, has_brim) {
-  difference(){
-    union(){
-      cylinder(d=$rounded_cherry_stem_d, h=depth);
-      if(has_brim) {
-        cylinder(d=$rounded_cherry_stem_d * 2, h=brim_height);
-      }
-    }
-
-    // inside cross
-    // translation purely for aesthetic purposes, to get rid of that awful lattice
-    translate([0,0,-0.005]) {
-      linear_extrude(height = $stem_throw) {
-        square($cherry_cross[0], center=true);
-        square($cherry_cross[1], center=true);
-      }
-    }
-  }
-}
-
-module alps_stem(depth, has_brim){
-  if(has_brim) {
-    linear_extrude(h=brim_height) {
-      square($alps_stem * [2,2], center = true);
-    }
-  }
-  linear_extrude(h=depth) {
-    square($alps_stem, center = true);
-  }
-}
-
-
-module filled_stem() {
-  // this is mostly for testing. we don't pass the size of the keycp in here
-  // so we can't make this work for all keys
-  cube(1000, center=true);
-}
-
-
-//whole stem, alps or cherry, trimmed to fit
-module stem(stem_type, depth, has_brim){
-    if (stem_type == "alps") {
-      alps_stem(depth, has_brim);
-    } else if (stem_type == "cherry_rounded") {
-      rounded_cherry_stem(depth, has_brim);
-    } else if (stem_type == "cherry") {
-      cherry_stem(depth, has_brim);
-    } else if (stem_type == "filled") {
-      filled_stem();
-    } else {
-      echo("Warning: unsupported $stem_type");
-    }
-}
-
-module cylindrical_dish(width, height, depth, inverted){
-  // .5 has problems starting around 3u
-  $fa=.25;
-  /* we do some funky math here
-   * basically you want to have the dish "dig in" to the keycap x millimeters
-   * in order to do that you have to solve a small (2d) system of equations
-   * where the chord of the spherical cross section of the dish is
-   * the width of the keycap.
-   */
-  // the distance you have to move the dish so it digs in depth millimeters
-  chord_length = (pow(width, 2) - 4 * pow(depth, 2)) / (8 * depth);
-  //the radius of the dish
-  rad = (pow(width, 2) + 4 * pow(depth, 2)) / (8 * depth);
-  direction = inverted ? -1 : 1;
-
-  translate([0,0, chord_length * direction]){
-    rotate([90, 0, 0]) cylinder(h=height + 20, r=rad, center=true);
-  }
-}
-
-//the older, 'more accurate', and MUCH slower spherical dish.
-// generates the largest sphere possible that still contains the chord we are looking for
-// much more graduated curvature at an immense cost
-module old_spherical_dish(width, height, depth, inverted){
-
-  //same thing as the cylindrical dish here, but we need the corners to just touch - so we have to find the hypotenuse of the top
-  chord = pow((pow(width,2) + pow(height, 2)),0.5); //getting diagonal of the top
-
-  // the distance you have to move the dish up so it digs in depth millimeters
-  chord_length = (pow(chord, 2) - 4 * pow(depth, 2)) / (8 * depth);
-  //the radius of the dish
-  rad = (pow(chord, 2) + 4 * pow(depth, 2)) / (8 * depth);
-  direction = inverted ? -1 : 1;
-
-  translate([0,0,chord_length * direction]){
-    if (geodesic){
-      $fa=7;
-      geodesic_sphere(r=rad);
-    } else {
-      $fa=1;
-      // rotate 1 because the bottom of the sphere looks like trash
-      sphere(r=rad);
-    }
-  }
-}
-
-module sideways_cylindrical_dish(width, height, depth, inverted){
-  $fa=1;
-  chord_length = (pow(height, 2) - 4 * pow(depth, 2)) / (8 * depth);
-  rad = (pow(height, 2) + 4 * pow(depth, 2)) / (8 * depth);
-
-  direction = inverted ? -1 : 1;
-
-  translate([0,0, chord_length * direction]){
-    // cylinder is rendered facing up, so we rotate it on the y axis first
-    rotate([0,90,0]) cylinder(h = width + 20,r=rad, center=true); // +20 for fudge factor
-  }
-}
-
-module spherical_dish(width, height, depth, inverted){
-
-  //same thing as the cylindrical dish here, but we need the corners to just touch - so we have to find the hypotenuse of the top
-  chord = pow((pow(width,2) + pow(height, 2)),0.5); //getting diagonal of the top
-
-  // the distance you have to move the dish up so it digs in depth millimeters
-  chord_length = (pow(chord, 2) - 4 * pow(depth, 2)) / (8 * depth);
-  //the radius of the dish
-  rad = (pow(chord, 2) + 4 * pow(depth, 2)) / (8 * depth);
-  direction = inverted ? -1 : 1;
-
-  translate([0,0,0 * direction]){
-    if (geodesic){
-      $fa=20;
-      scale([chord/2/depth, chord/2/depth]) {
-        geodesic_sphere(r=depth);
-      }
-    } else {
-      $fa=7;
-      // rotate 1 because the bottom of the sphere looks like trash.
-      scale([chord/2/depth, chord/2/depth]) {
-        geodesic_sphere(r=depth);
-      }
-    }
-  }
-}
-
-//geodesic looks much better, but runs very slow for anything above a 2u
-geodesic=false;
-
-//dish selector
-module  dish(width, height, depth, inverted) {
-    if($dish_type == "cylindrical"){
-      cylindrical_dish(width, height, depth, inverted);
-    }
-    else if ($dish_type == "spherical") {
-      spherical_dish(width, height, depth, inverted);
-    }
-    else if ($dish_type == "sideways cylindrical"){
-      sideways_cylindrical_dish(width, height, depth, inverted);
-    }
-    else if ($dish_type == "old spherical") {
-      old_spherical_dish(width, height, depth, inverted);
-    } else {
-      // else no dish, "no dish" is the value
-      // switchted to actually diffing a cube here due to changes to stems being differenced from the dish instead of the inside
-      translate([0,0,500]) cube([width, height, 1000], center=true);
-    }
-}
-
-// figures out the scale factor needed to make a 45 degree wall
-function scale_for_45(height, starting_size) = (height * 2 + starting_size) / starting_size;
-
-// complicated since we want the different stems to work well
-// also kind of messy... oh well
-module flared_support(stem_type, loft, height) {
-  translate([0,0,loft]){
-    if(stem_type == "cherry") {
-      cherry_scale = [scale_for_45(height, $cherry_stem[0]), scale_for_45(height, $cherry_stem[1])];
-      linear_extrude(height=height, scale = cherry_scale){
-        offset(r=1){
-          square($cherry_stem - [2,2], center=true);
-        }
-      }
-    } else if (stem_type == "cherry_rounded") {
-      linear_extrude(height=height, scale = scale_for_45(height, $rounded_cherry_stem_d)){
-        circle(d=$rounded_cherry_stem_d);
-      }
-    } else if (stem_type == "alps") {
-      alps_scale = [scale_for_45(height, $alps_stem[0]), scale_for_45(height, $alps_stem[1])];
-      linear_extrude(height=height, scale = alps_scale){
-        square($alps_stem, center=true);
-      }
-    }
-  }
-}
-
-module flat_support(stem_type, loft, height) {
-  translate([0,0,loft + 500]){
-    cube(1000, center=true);
-  }
-}
-
-module bars_support(stem_type, loft, height) {
-  translate([0,0,loft + height / 2]){
-    cube([2, 100, height], center = true);
-    cube([100, 2, height], center = true);
-  }
-}
-
-module supports(type, stem_type, loft, height) {
-  if (type == "flared") {
-    flared_support(stem_type, loft, height);
-  } else if (type == "flat") {
-    flat_support(stem_type, loft, height);
-  } else if (type == "bars") {
-    bars_support(stem_type, loft, height);
-  } else {
-    echo("Warning: unsupported $support_type");
-  }
-}
-
+/* [Hidden] */
 $fs = .1;
 unit = 19.05;
 color1 = [.2667,.5882,1];
 color2 = [.5412, .4784, 1];
 color3 = [.4078, .3569, .749];
 color4 = [1, .6941, .2];
-transparent_red = [1,0,0, 0.5];
+transparent_red = [1,0,0, 0.15];
 
 // derived values. can't be variables if we want them to change when the special variables do
 
@@ -602,21 +678,19 @@ function top_total_key_height() = $bottom_key_height + (unit * ($key_height - 1)
 // key shape including dish. used as the ouside and inside shape in keytop(). allows for itself to be shrunk in depth and width / height
 module shape(thickness_difference, depth_difference){
   dished(depth_difference, $inverted_dish) {
-    color(color1) shape_hull(thickness_difference, depth_difference, 1);
+    color(color1) shape_hull(thickness_difference, depth_difference, 2);
   }
 }
 
 // shape of the key but with soft, rounded edges. much more realistic, MUCH more complex. orders of magnitude more complex
 module rounded_shape() {
-  render(){
-    color(color1) minkowski(){
-      // half minkowski. that means the shape is neither circumscribed nor inscribed.
-      shape($minkowski_radius * 2, $minkowski_radius/2);
-      difference(){
-        sphere(r=$minkowski_radius, $fn=24);
-        translate([0,0,-$minkowski_radius]){
-          cube($minkowski_radius * 2, center=true);
-        }
+  color(color1) minkowski(){
+    // half minkowski in the z direction
+    shape($minkowski_radius * 2, $minkowski_radius/2);
+    difference(){
+      sphere(r=$minkowski_radius, $fn=20);
+      translate([0,0,-$minkowski_radius]){
+        cube($minkowski_radius * 2, center=true);
       }
     }
   }
@@ -695,7 +769,7 @@ module inside() {
 // put something at the top of the key, with no adjustments for dishing
 module top_placement(depth_difference) {
   translate([$dish_skew_x, $top_skew + $dish_skew_y, $total_depth - depth_difference]){
-    rotate([-$top_tilt / top_total_key_height(),0,0]){
+    rotate([-$top_tilt / $key_height,0,0]){
       children();
     }
   }
@@ -736,16 +810,18 @@ module top_of_key(){
   }
 }
 
-module keytext(text, depth = 0) {
-  translate([0, 0, -depth]){
+module keytext(text, position, font_size, depth) {
+  woffset = (top_total_key_width()/3.5) * position[0];
+  hoffset = (top_total_key_height()/3.5) * -position[1];
+  translate([woffset, hoffset, -depth]){
     linear_extrude(height=$dish_depth){
-      text(text=text, font=$font, size=$font_size, halign="center", valign="center");
+      text(text=text, font=$font, size=font_size, halign="center", valign="center");
     }
   }
 }
 
-module keystem_positions() {
-  for (connector_pos = $connectors) {
+module keystem_positions(positions) {
+  for (connector_pos = positions) {
     translate(connector_pos) {
       rotate([0, 0, $stem_rotation]){
         children();
@@ -754,15 +830,15 @@ module keystem_positions() {
   }
 }
 
-module keystems() {
-  keystem_positions() {
-    color(color4) stem($stem_type, $total_depth, $has_brim);
+module support_for(positions, stem_type) {
+  keystem_positions(positions) {
+    color(color4) supports($support_type, stem_type, $stem_throw, $total_depth - $stem_throw);
   }
 }
 
-module keystem_supports() {
-  keystem_positions() {
-    color(color4) supports($support_type, $stem_type, $stem_throw, $total_depth - $stem_throw);
+module stems_for(positions, stem_type) {
+  keystem_positions(positions) {
+    color(color4) stem(stem_type, $total_depth, $has_brim, $stem_slop);
   }
 }
 
@@ -792,10 +868,12 @@ module clearance_check() {
 }
 
 // legends / artisan support
-module artisan(legend, depth) {
+module artisan(depth) {
   top_of_key() {
     // outset legend
-    if (legend != "") keytext(legend, depth);
+    for (i=[0:len($legends)-1]) {
+        keytext($legends[i][0], $legends[i][1], $legends[i][2], depth);
+    }
     // artisan objects / outset shape legends
     children();
   }
@@ -819,38 +897,282 @@ module keytop() {
 
 // The final, penultimate key generation function.
 // takes all the bits and glues them together. requires configuration with special variables.
-module key(legend = "", inset = false) {
+module key(inset = false) {
   difference() {
     union(){
       // the shape of the key, inside and out
       keytop();
+      if($key_bump) top_of_key() keybump($key_bump_depth, $key_bump_edge);
       // additive objects at the top of the key
-      if(!inset) artisan(legend) children();
+      if(!inset) artisan() children();
       // render the clearance check if it's enabled, but don't have it intersect with anything
       if ($clearance_check) %clearance_check();
     }
 
     // subtractive objects at the top of the key
-    if (inset) artisan(legend, 0.3) children();
+    if (inset) artisan(0.3) children();
     // subtract the clearance check if it's enabled, letting the user see the
     // parts of the keycap that will hit the cherry switch
     if ($clearance_check) clearance_check();
   }
 
   // both stem and support are optional
-  if ($stem_type){
+  if ($stem_type || $stabilizer_type) {
     dished($keytop_thickness, $inverted_dish) {
-      translate([0, 0, $stem_inset]) keystems();
+      translate([0, 0, $stem_inset]) {
+        if ($stabilizer_type) stems_for($stabilizers, $stabilizer_type);
+        if ($stem_type) stems_for($stem_positions, $stem_type);
+      }
     }
   }
 
   if ($support_type){
     inside() {
-      translate([0, 0, $stem_inset]) keystem_supports();
+      translate([0, 0, $stem_inset]) {
+        if ($stabilizer_type) support_for($stabilizers, $stabilizer_type);
+
+        // always render stem support even if there isn't a stem.
+        // rendering flat support w/no stem is much more common than a hollow keycap
+        // so if you want a hollow keycap you'll have to turn support off entirely
+        support_for($stem_positions, $stem_type);
+      }
     }
   }
 }
 
+// actual full key with space carved out and keystem/stabilizer connectors
+// this is an example key with all the fixins from settings.scad
+module example_key(){
+// keytop thickness, aka how many millimeters between the inside and outside of the top surface of the key
+$keytop_thickness = 1;
+// wall thickness, aka the thickness of the sides of the keycap. note this is the total thickness, aka 3 = 1.5mm walls
+$wall_thickness = 3;
+//whether stabilizer connectors are enabled
+$stabilizers = false;
+// font used for text
+$font="DejaVu Sans Mono:style=Book";
+// font size used for text
+$font_size = 6;
+// whether or not to render fake keyswitches to check clearances
+$clearance_check = false;
+
+/* [Key profile] */
+
+// width of the very bottom of the key
+$bottom_key_width = 18.16;
+// height (from the front) of the very bottom of the ke
+$bottom_key_height = 18.16;
+// how much less width there is on the top. eg top_key_width = bottom_key_width - width_difference
+$width_difference = 6;
+// how much less height there is on the top
+$height_difference = 4;
+// how deep the key is, before adding a dish
+$total_depth = 11.5;
+// the tilt of the dish in degrees. divided by key height
+$top_tilt = -6;
+// how skewed towards the back the top is (0 for center)
+$top_skew = 1.7;
+// what type of dish the key has. note that unlike stems and supports a dish ALWAYS gets rendered.
+$dish_type = "cylindrical";
+// how deep the dish 'digs' into the top of the keycap. this is max depth, so you can't find the height from total_depth - dish_depth. besides the top is skewed anyways
+$dish_depth = 1;
+// how skewed in the x direction the dish is
+$dish_skew_x = 0;
+// how skewed in the y direction (height) the dish is
+$dish_skew_y = 0;
+//length in units of key
+$key_length = 1;
+//height in units of key. should remain 1 for most uses
+$key_height = 1;
+//print brim for connector to help with bed adhesion
+$has_brim = false;
+//when $has_brim this is the height of the brim
+$brim_height = 0.2;
+// invert dishing. mostly for spacebar
+$inverted_dish = false;
+// array of positions of stabilizers
+// ternary is a bad hack to keep the stabilizers flag working
+$stabilizers = [[-50,0],[50,0]];
+// use linear_extrude instead of hull slices to make the shape of the key
+// should be faster, also required for concave shapes
+$linear_extrude_shape = false;
+//should the key be rounded? unnecessary for most printers, and very slow
+$rounded_key = false;
+// what type of stem you want. To turn off stems pass false. "cherry", "alps", and "cherry_rounded" supported
+$stem_type = "cherry";
+// where the stems are in relation to the center of the keycap, in units. default is one in the center
+$stem_positions = [[0,0]];
+// what type of stem you want for the stabilizers. false disables
+$stabilizer_type = false;
+// how much higher the stem is than the bottom of the keycap.
+// inset stem requires support but is more accurate in some profiles
+$stem_inset = 0;
+// how many degrees to rotate the stems. useful for sideways keycaps, maybe
+$stem_rotation = 0;
+// radius of corners of keycap
+$corner_radius = 1;
+// support type. default is "flared" for easy FDM printing. to disable pass false
+$support_type = "flared";
+// key shape type, determines the shape of the key. default is 'rounded square'
+$key_shape_type = "rounded_square";
+// ISO enter needs to be linear extruded NOT from the center. this tells the program how far up 'not from the center' is
+$linear_extrude_height_adjustment = 0;
+// if you need the dish to extend further, you can 'overdraw' the rectangle it will hit
+$dish_overdraw_width = 0;
+// same as width but for height
+$dish_overdraw_height = 0;
+// how many slices will be made, to approximate curves on corners. Leave at 1 if you are not curving corners
+// if you're doing fancy bowed keycap sides, this controls how many slices you take
+$height_slices = 1;
+
+//minkowski radius. radius of sphere used in minkowski sum for minkowski_key function. 1.75 for G20
+$minkowski_radius = .33;
+
+
+// [ Stem Variables ]
+
+
+// the stem is the hardest part to print, so this variable controls how much 'slop' there is in the stem
+$stem_slop = 0.3;
+
+// how tall in mm the brim is, if there is one. brim sits around the keystem and helps to secure it while printing.
+$brim_height = 0.4;
+// how far the throw distance of the switch is. determines how far the 'cross' in the cherry switch digs into the stem, and how long the keystem needs to be before supports can start. luckily, alps and cherries have a pretty similar throw. can modify to have stouter keycaps for low profile switches, etc
+$stem_throw = 4;
+
+// diameter of the outside of the rounded cherry stem
+$rounded_cherry_stem_d = 5.5;
+
+// dimensions of alps stem
+$alps_stem = [4.45, 2.25];
+
+//list of legends to place on a key format: [text, halign, valign, size]
+//halign = "left" or "center" or "right"
+//valign = "top" or "center" or "bottom"
+$legends = [];
+//insert locating bump
+$key_bump = false;
+//height of the location bump from the top surface of the key
+$key_bump_depth = 0.5;
+//distance to move the bump from the front edge of the key
+$key_bump_edge = 0.4;
+  key();
+}
+
+
+// keytop thickness, aka how many millimeters between the inside and outside of the top surface of the key
+$keytop_thickness = 1;
+// wall thickness, aka the thickness of the sides of the keycap. note this is the total thickness, aka 3 = 1.5mm walls
+$wall_thickness = 3;
+//whether stabilizer connectors are enabled
+$stabilizers = false;
+// font used for text
+$font="DejaVu Sans Mono:style=Book";
+// font size used for text
+$font_size = 6;
+// whether or not to render fake keyswitches to check clearances
+$clearance_check = false;
+
+/* [Key profile] */
+
+// width of the very bottom of the key
+$bottom_key_width = 18.16;
+// height (from the front) of the very bottom of the ke
+$bottom_key_height = 18.16;
+// how much less width there is on the top. eg top_key_width = bottom_key_width - width_difference
+$width_difference = 6;
+// how much less height there is on the top
+$height_difference = 4;
+// how deep the key is, before adding a dish
+$total_depth = 11.5;
+// the tilt of the dish in degrees. divided by key height
+$top_tilt = -6;
+// how skewed towards the back the top is (0 for center)
+$top_skew = 1.7;
+// what type of dish the key has. note that unlike stems and supports a dish ALWAYS gets rendered.
+$dish_type = "cylindrical";
+// how deep the dish 'digs' into the top of the keycap. this is max depth, so you can't find the height from total_depth - dish_depth. besides the top is skewed anyways
+$dish_depth = 1;
+// how skewed in the x direction the dish is
+$dish_skew_x = 0;
+// how skewed in the y direction (height) the dish is
+$dish_skew_y = 0;
+//length in units of key
+$key_length = 1;
+//height in units of key. should remain 1 for most uses
+$key_height = 1;
+//print brim for connector to help with bed adhesion
+$has_brim = false;
+//when $has_brim this is the height of the brim
+$brim_height = 0.2;
+// invert dishing. mostly for spacebar
+$inverted_dish = false;
+// array of positions of stabilizers
+// ternary is a bad hack to keep the stabilizers flag working
+$stabilizers = [[-50,0],[50,0]];
+// use linear_extrude instead of hull slices to make the shape of the key
+// should be faster, also required for concave shapes
+$linear_extrude_shape = false;
+//should the key be rounded? unnecessary for most printers, and very slow
+$rounded_key = false;
+// what type of stem you want. To turn off stems pass false. "cherry", "alps", and "cherry_rounded" supported
+$stem_type = "cherry";
+// where the stems are in relation to the center of the keycap, in units. default is one in the center
+$stem_positions = [[0,0]];
+// what type of stem you want for the stabilizers. false disables
+$stabilizer_type = false;
+// how much higher the stem is than the bottom of the keycap.
+// inset stem requires support but is more accurate in some profiles
+$stem_inset = 0;
+// how many degrees to rotate the stems. useful for sideways keycaps, maybe
+$stem_rotation = 0;
+// radius of corners of keycap
+$corner_radius = 1;
+// support type. default is "flared" for easy FDM printing. to disable pass false
+$support_type = "flared";
+// key shape type, determines the shape of the key. default is 'rounded square'
+$key_shape_type = "rounded_square";
+// ISO enter needs to be linear extruded NOT from the center. this tells the program how far up 'not from the center' is
+$linear_extrude_height_adjustment = 0;
+// if you need the dish to extend further, you can 'overdraw' the rectangle it will hit
+$dish_overdraw_width = 0;
+// same as width but for height
+$dish_overdraw_height = 0;
+// how many slices will be made, to approximate curves on corners. Leave at 1 if you are not curving corners
+// if you're doing fancy bowed keycap sides, this controls how many slices you take
+$height_slices = 1;
+
+//minkowski radius. radius of sphere used in minkowski sum for minkowski_key function. 1.75 for G20
+$minkowski_radius = .33;
+
+
+// [ Stem Variables ]
+
+
+// the stem is the hardest part to print, so this variable controls how much 'slop' there is in the stem
+$stem_slop = 0.3;
+
+// how tall in mm the brim is, if there is one. brim sits around the keystem and helps to secure it while printing.
+$brim_height = 0.4;
+// how far the throw distance of the switch is. determines how far the 'cross' in the cherry switch digs into the stem, and how long the keystem needs to be before supports can start. luckily, alps and cherries have a pretty similar throw. can modify to have stouter keycaps for low profile switches, etc
+$stem_throw = 4;
+
+// diameter of the outside of the rounded cherry stem
+$rounded_cherry_stem_d = 5.5;
+
+// dimensions of alps stem
+$alps_stem = [4.45, 2.25];
+
+//list of legends to place on a key format: [text, halign, valign, size]
+//halign = "left" or "center" or "right"
+//valign = "top" or "center" or "bottom"
+$legends = [];
+//insert locating bump
+$key_bump = false;
+//height of the location bump from the top surface of the key
+$key_bump_depth = 0.5;
+//distance to move the bump from the front edge of the key
+$key_bump_edge = 0.4;
 // key width functions
 
 module u(u=1) {
@@ -920,7 +1242,6 @@ module 2_75uh() {
 module 6_25uh() {
   uh(6.25) children();
 }
-
 // key profile definitions
 
 // unlike the other files with their own dedicated folders, this one doesn't need a selector. it just collects all the functions
@@ -958,7 +1279,6 @@ module dcs_row(n=1) {
     children();
   }
 }
-
 module oem_row(n=1) {
   $bottom_key_width = 18.05;
   $bottom_key_height = 18.05;
@@ -993,14 +1313,15 @@ module oem_row(n=1) {
     children();
   }
 }
-
 module dsa_row(n=3) {
+  $key_shape_type = "sculpted_square";
+  depth_raisers = [0, 3.5, 1, 0, 1, 3];
   $bottom_key_width = 18.24; // 18.4;
   $bottom_key_height = 18.24; // 18.4;
   $width_difference = 6; // 5.7;
   $height_difference = 6; // 5.7;
-  $total_depth = 8.1 + abs((n-3) * 1);
-  $top_tilt = (n-3) * -7;
+  $total_depth = 8.1 + depth_raisers[n];
+  $top_tilt = n == 5 ? -21 : (n-3) * 7;
   $top_skew = 0;
   $dish_type = "spherical";
   $dish_depth = 1.2;
@@ -1014,8 +1335,8 @@ module dsa_row(n=3) {
 
   children();
 }
-
 module sa_row(n=1) {
+  $key_shape_type = "sculpted_square";
   $bottom_key_width = 18.4;
   $bottom_key_height = 18.4;
   $width_difference = 5.7;
@@ -1026,12 +1347,14 @@ module sa_row(n=1) {
   $dish_skew_y = 0;
   $top_skew = 0;
   $height_slices = 10;
-  $enable_side_sculpting = true;
   // might wanna change this if you don't minkowski
   // do you even minkowski bro
   $corner_radius = 0.25;
-
-  if (n == 1){
+  // 5th row is usually unsculpted or the same as the row below it
+  // making a super-sculpted top row (or bottom row!) would be real easy
+  // bottom row would just be 13 tilt and 14.89 total depth
+  // top row would be something new entirely - 18 tilt maybe?
+  if (n == 1 || n == 5){
     $total_depth = 14.89;
     $top_tilt = -13;
     children();
@@ -1039,7 +1362,7 @@ module sa_row(n=1) {
     $total_depth = 12.925;
     $top_tilt = -7;
     children();
-  } else if (n == 3) {
+  } else if (n == 3 || n == 5) {
     $total_depth = 12.5;
     $top_tilt = 0;
     children();
@@ -1049,23 +1372,24 @@ module sa_row(n=1) {
     children();
   }
 }
-
 module g20_row(n=3) {
   $bottom_key_width = 18.16;
   $bottom_key_height = 18.16;
   $width_difference = 2;
   $height_difference = 2;
-  $total_depth = 6;
+  $total_depth = 6 + abs((n-3) * 0.5);
   $top_tilt = 2.5;
-  $top_tilt = (n-3) * -7 + 2.5;
+  $top_tilt =  n == 5 ? -18.5 : (n-3) * 7 + 2.5;
   $top_skew = 0.75;
   $dish_type = "no dish";
   $dish_depth = 0;
   $dish_skew_x = 0;
   $dish_skew_y = 0;
   $minkowski_radius = 1.75;
+    $key_bump_depth = 0.6;
+    $key_bump_edge = 2;
   //also,
-  /*$rounded_key = true;*/
+  $rounded_key = true;
 
 
   children();
@@ -1085,7 +1409,6 @@ module key_profile(key_profile_type, row) {
     g20_row(row) children();
   }
 }
-
 module spacebar() {
   $inverted_dish = true;
   $dish_type = "sideways cylindrical";
@@ -1122,9 +1445,7 @@ module numpad_0() {
 
 module stepped_caps_lock() {
   u(1.75) {
-    $connectors = [
-      [-5, 0]
-    ];
+    $stem_positions = [[-5, 0]];
     children();
   }
 }
@@ -1145,89 +1466,161 @@ module iso_enter() {
     children();
   }
 }
+// kind of a catch-all at this point for any directive that doesn't fit in the other files
 
+//TODO duplicate def to not make this a special var. maybe not worth it
+unit = 19.05;
 
+module translate_u(x=0, y=0, z=0){
+  translate([x * unit, y*unit, z*unit]) children();
+}
 
+module brimmed(height = 0.2) {
+  $has_brim = true;
+  $brim_height = height;
+  children();
+}
 
+module rounded() {
+  $rounded_key = true;
+  children();
+}
 
+module inverted() {
+  $inverted_dish = true;
+  children();
+}
 
+module rotated() {
+  $stem_rotation = 90;
+  children();
+}
 
+module stabilized(mm=12, vertical = false, type="cherry") {
+  if (vertical) {
+    $stabilizer_type = type;
+    $stabilizers = [
+    [0,  mm],
+    [0, -mm]
+    ];
 
+    children();
+  } else {
+    $stabilizer_type = type;
+    $stabilizers = [
+      [mm,  0],
+      [-mm, 0]
+    ];
 
+    children();
+  }
+}
 
+module dishless() {
+  $dish_type = "no dish";
+  children();
+}
 
+module inset(val=1) {
+  $stem_inset = val;
+  children();
+}
 
+module filled() {
+  $stem_type = "filled";
+  children();
+}
 
+module blank() {
+  $stem_type = "blank";
+  children();
+}
 
+module cherry(slop) {
+  $stem_slop = slop ? slop : $stem_slop;
+  $stem_type = "cherry";
+  children();
+}
 
+module alps(slop) {
+  $stem_slop = slop ? slop : $stem_slop;
+  $stem_type = "alps";
+  children();
+}
 
+module rounded_cherry(slop) {
+  $stem_slop = slop ? slop : $stem_slop;
+  $stem_type = "cherry_rounded";
+  children();
+}
 
+module flared_support() {
+  $support_type = "flared";
+  children();
+}
 
+module bar_support() {
+  $support_type = "bars";
+  children();
+}
 
+module flat_support() {
+  $support_type = "flat";
+  children();
+}
 
+module legend(text, position=[0,0], size=undef) {
+    font_size = size == undef ? $font_size : size;
+    $legends = [for(L=[$legends, [[text, position, font_size]]], a=L) a];
+    children();
+}
 
+module bump(depth=undef) {
+    $key_bump = true;
+    $key_bump_depth = depth == undef ? $key_bump_depth : depth;
+    children();
+}
 
+module translate_u(x=0, y=0, z=0){
+  translate([x * unit, y*unit, z*unit]) children();
+}
 
+// row 5 is commonly the top row, for whatever reason
+key_profiles = ["dcs", "oem", "sa", "g20", "dsa"];
 
+module one_single_key(profile, row, unsculpted) {
+   key_profile(profile, unsculpted ? 3 : row) cherry() key();
+}
 
+module one_row_profile(profile, unsculpted = false) {
+  rows = [5, 1, 2, 3, 4];
+  for(row = [0:len(rows)-1]) {
+    translate_u(0, -row) one_single_key(profile, rows[row], unsculpted);
+  }
+}
 
+for (p = [0:len(key_profiles)-1]) {
+  translate_u(p){
+    /* one_row_profile(key_profiles[p]); */
+  }
+}
 
+/* translate_u(0, 0) one_row_profile("oem"); */
+/* dsa_row(3) u(1) uh(1) cherry() key(); */
 
-
-
-// ok, the actual script now
-
-/* [General] */
-
-// keytop thickness, aka how many millimeters between the inside and outside of the top surface of the key
-$keytop_thickness = 1; // [0.5:0.1:5]
-// wall thickness, aka the thickness of the sides of the keycap. note this is the total thickness, aka 3 = 1.5mm walls
-$wall_thickness = 3; // [1:10]
-//whether stabilizer connectors are enabled
-$stabilizers = false;
-
-/* [Legends] */
-
-// font used for text
-$font="DejaVu Sans Mono:style=Book";
-// font size used for text
-$font_size = 6;
-
-/* [Key profile] */
-
-//length in units of key
-$key_length = 10; // [1:0.25:10]
-//height in units of key. should remain 1 for most uses
-$key_height = 10; // [1:0.25:10]
-//print brim for connector to help with bed adhesion
-$has_brim = false;
-// invert dishing. mostly for spacebar
-$inverted_dish = false;
-
-
-// what type of stem you want. To turn off stems pass false. "cherry", "alps", and "cherry_rounded" supported
-$stem_type = "cherry"; // ["cherry", "cherry_rounded", "alps", "filled", false]
-// how much higher the stem is than the bottom of the keycap.
-// inset stem requires support but is more accurate in some profiles
-$stem_inset = 0; // [0:0.125:10]
-// how many degrees to rotate the stems. useful for sideways keycaps, maybe
-$stem_rotation = 0; // [0:45:360]
-// keystem slop - lengthens the cross and thins out the connector
-$stem_slop = 0.3; // [0:0.1:1]
-// support type. default is "flared" for easy FDM printing. to disable pass false
-$support_type = "flat"; // ["flared", "flat", "bars", false]
-// key shape type, determines the shape of the key. default is 'rounded square'
-$key_shape_type = "rounded_square"; // ["rounded_square", "square", "ISO_enter", "oblong"]
-
-/* [ Brim ] */
-
-// how tall in mm the brim is, if there is one. brim sits around the keystem and helps to secure it while printing.
-$brim_height = 0.4; // [0:0.1:3]
-
-key_profile_type = "dcs"; // ["dcs", "sa", "dsa", "oem", "g20"]
-
-row = 3; // [1:5]
-
-key_profile(key_profile_type, row) {
+translate_u(0, 0) sa_row(3) stepped_caps_lock() {
   key();
 }
+
+translate_u(0, 1) sa_row(2) lshift() {
+  $stem_type = false;
+  key();
+}
+
+translate_u(0, 2) sa_row(1) spacebar() alps() {
+  $support_type = false;
+  key();
+}
+
+/* sculpted_square_shape([19,19], [0,0], 0.3);
+translate([26,0,0]) rounded_square_shape([19,19], [0,0], 0.3); */

--- a/key/customizer.scad
+++ b/key/customizer.scad
@@ -13,24 +13,24 @@ legend = "";
 
 /* [Basic-Settings] */
 
-// what type of stem you want. Most people want Cherry.
+// What type of stem you want. Most people want Cherry.
 $stem_type = "cherry";  // [cherry, alps, rounded_cherry, box_cherry, filled, disable]
 
-// support type. default is "flared" for easy FDM printing; bars are more realistic, and flat could be for artisans
+// Support type. default is "flared" for easy FDM printing; bars are more realistic, and flat could be for artisans
 $support_type = "flared"; // [flared, bars, flat, disable]
 
-// length in units of key. A regular key is 1 unit; spacebar is usually 6.25
-$key_length = 1.0; // range not working in thingiverse customizer atm [1:0.25:16]
+// Length in units of key. A regular key is 1 unit; spacebar is usually 6.25
+$key_length = 1.0; // Range not working in thingiverse customizer atm [1:0.25:16]
 
-// supports for the stem, as it often comes off during printing. disabled by default, but highly reccommended.
+// Supports for the stem, as it often comes off during printing. disabled by default, but highly reccommended.
 $stem_support_type = "disable"; // [brim, tines, disabled]
-// the stem is the hardest part to print, so this variable controls how much 'slop' there is in the stem
-$stem_slop = 0.3; // not working in thingiverse customizer atm [0:0.01:1]
+// The stem is the hardest part to print, so this variable controls how much 'slop' there is in the stem
+$stem_slop = 0.3; // Not working in thingiverse customizer atm [0:0.01:1]
 
-// font size used for text
+// Font size used for text
 $font_size = 6;
 
-// invert dishing. mostly for spacebar
+// Invert dishing. mostly for spacebar
 $inverted_dish = false;
 
 // Enable stabilizers. If you don't want stabilizers use disable; most other keycaps use Cherry stabilizers
@@ -39,80 +39,80 @@ $stabilizer_type = "disable"; // [cherry, rounded_cherry, alps, disable]
 /* [Advanced] */
 
 /* Key */
-// height in units of key. should remain 1 for most uses
+// Height in units of key. should remain 1 for most uses
 $key_height = 1.0;
-// keytop thickness, aka how many millimeters between the inside and outside of the top surface of the key
+// Keytop thickness, aka how many millimeters between the inside and outside of the top surface of the key
 $keytop_thickness = 1;
-// wall thickness, aka the thickness of the sides of the keycap. note this is the total thickness, aka 3 = 1.5mm walls
+// Wall thickness, aka the thickness of the sides of the keycap. note this is the total thickness, aka 3 = 1.5mm walls
 $wall_thickness = 3;
-// radius of corners of keycap
+// Radius of corners of keycap
 $corner_radius = 1;
-// width of the very bottom of the key
+// Width of the very bottom of the key
 $bottom_key_width = 18.16;
-// height (from the front) of the very bottom of the key
+// Height (from the front) of the very bottom of the key
 $bottom_key_height = 18.16;
-// how much less width there is on the top. eg top_key_width = bottom_key_width - width_difference
+// How much less width there is on the top. eg top_key_width = bottom_key_width - width_difference
 $width_difference = 6;
-// how much less height there is on the top
+// How much less height there is on the top
 $height_difference = 4;
-// how deep the key is, before adding a dish
+// How deep the key is, before adding a dish
 $total_depth = 11.5;
-// the tilt of the dish in degrees. divided by key height
+// The tilt of the dish in degrees. divided by key height
 $top_tilt = -6;
-// how skewed towards the back the top is (0 for center)
+// How skewed towards the back the top is (0 for center)
 $top_skew = 1.7;
 
 /* Stem */
 
-// how far the throw distance of the switch is. determines how far the 'cross' in the cherry switch digs into the stem, and how long the keystem needs to be before supports can start. luckily, alps and cherries have a pretty similar throw. can modify to have stouter keycaps for low profile switches, etc
+// How far the throw distance of the switch is. determines how far the 'cross' in the cherry switch digs into the stem, and how long the keystem needs to be before supports can start. luckily, alps and cherries have a pretty similar throw. can modify to have stouter keycaps for low profile switches, etc
 $stem_throw = 4;
-// diameter of the outside of the rounded cherry stem
+// Diameter of the outside of the rounded cherry stem
 $rounded_cherry_stem_d = 5.5;
 
 
-// how much higher the stem is than the bottom of the keycap.
-// inset stem requires support but is more accurate in some profiles
+// How much higher the stem is than the bottom of the keycap.
+// Inset stem requires support but is more accurate in some profiles
 $stem_inset = 0;
-// how many degrees to rotate the stems. useful for sideways keycaps, maybe
+// How many degrees to rotate the stems. useful for sideways keycaps, maybe
 $stem_rotation = 0;
 
 /* Shape */
 
-// key shape type, determines the shape of the key. default is 'rounded square'
+// Key shape type, determines the shape of the key. default is 'rounded square'
 $key_shape_type = "rounded_square";
 // ISO enter needs to be linear extruded NOT from the center. this tells the program how far up 'not from the center' is
 $linear_extrude_height_adjustment = 0;
-// how many slices will be made, to approximate curves on corners. Leave at 1 if you are not curving corners
-// if you're doing fancy bowed keycap sides, this controls how many slices you take
+// How many slices will be made, to approximate curves on corners. Leave at 1 if you are not curving corners
+// If you're doing fancy bowed keycap sides, this controls how many slices you take
 $height_slices = 1;
 
 /* Dish */
 
-// what type of dish the key has. note that unlike stems and supports a dish ALWAYS gets rendered.
+// What type of dish the key has. note that unlike stems and supports a dish ALWAYS gets rendered.
 $dish_type = "cylindrical"; // [cylindrical, spherical, sideways cylindrical, old spherical, disable]
-// how deep the dish 'digs' into the top of the keycap. this is max depth, so you can't find the height from total_depth - dish_depth. besides the top is skewed anyways
+// How deep the dish 'digs' into the top of the keycap. this is max depth, so you can't find the height from total_depth - dish_depth. besides the top is skewed anyways
 $dish_depth = 1;
-// how skewed in the x direction the dish is
+// How skewed in the x direction the dish is
 $dish_skew_x = 0;
-// how skewed in the y direction (height) the dish is
+// How skewed in the y direction (height) the dish is
 $dish_skew_y = 0;
-// if you need the dish to extend further, you can 'overdraw' the rectangle it will hit
+// If you need the dish to extend further, you can 'overdraw' the rectangle it will hit
 $dish_overdraw_width = 0;
-// same as width but for height
+// Same as width but for height
 $dish_overdraw_height = 0;
 
 /* Misc */
-// there's a bevel on the cherry stems to aid insertion / guard against first layer squishing making a hard-to-fit stem.
+// There's a bevel on the cherry stems to aid insertion / guard against first layer squishing making a hard-to-fit stem.
 $cherry_bevel = true;
 
-// how tall in mm the stem support is, if there is any. stem support sits around the keystem and helps to secure it while printing.
+// How tall in mm the stem support is, if there is any. stem support sits around the keystem and helps to secure it while printing.
 $stem_support_height = 0.4;
-// font used for text
+// Font used for text
 $font="DejaVu Sans Mono:style=Book";
-// whether or not to render fake keyswitches to check clearances
+// Whether or not to render fake keyswitches to check clearances
 $clearance_check = false;
-// use linear_extrude instead of hull slices to make the shape of the key
-// should be faster, also required for concave shapes
+// Use linear_extrude instead of hull slices to make the shape of the key
+// Should be faster, also required for concave shapes
 $linear_extrude_shape = false;
 //should the key be rounded? unnecessary for most printers, and very slow
 $rounded_key = false;
@@ -133,20 +133,20 @@ $key_bump_edge = 0.4;
 //list of legends to place on a key format: [text, halign, valign, size]
 //halign = "left" or "center" or "right"
 //valign = "top" or "center" or "bottom"
-// currently does not work with thingiverse customizer, and actually breaks it
+// Currently does not work with thingiverse customizer, and actually breaks it
 $legends = [];
 
-// dimensions of alps stem
+// Dimensions of alps stem
 $alps_stem = [4.45, 2.25];
 
-// ternary is ONLY for customizer. it will NOT work if you're using this in
-// openSCAD, unless you're using the customizer. you should use stabilized() or
-// set the variable directly
-// array of positions of stabilizers
+// Ternary is ONLY for customizer. it will NOT work if you're using this in
+// OpenSCAD, unless you're using the customizer. you should use stabilized() or
+// Set the variable directly
+// Array of positions of stabilizers
 $stabilizers = $key_length > 5.75 ? [[-50, 0], [50, 0]] : [[-12,0],[12,0]];
 
-// where the stems are in relation to the center of the keycap, in units. default is one in the center
-// shouldn't work in thingiverse customizer, though it has been...
+// Where the stems are in relation to the center of the keycap, in units. default is one in the center
+// Shouldn't work in thingiverse customizer, though it has been...
 $stem_positions = [[0,0]];
 
 // key width functions
@@ -2071,24 +2071,24 @@ module key(inset = false) {
 module example_key(){
 /* [Basic-Settings] */
 
-// what type of stem you want. Most people want Cherry.
+// What type of stem you want. Most people want Cherry.
 $stem_type = "cherry";  // [cherry, alps, rounded_cherry, box_cherry, filled, disable]
 
-// support type. default is "flared" for easy FDM printing; bars are more realistic, and flat could be for artisans
+// Support type. default is "flared" for easy FDM printing; bars are more realistic, and flat could be for artisans
 $support_type = "flared"; // [flared, bars, flat, disable]
 
-// length in units of key. A regular key is 1 unit; spacebar is usually 6.25
-$key_length = 1.0; // range not working in thingiverse customizer atm [1:0.25:16]
+// Length in units of key. A regular key is 1 unit; spacebar is usually 6.25
+$key_length = 1.0; // Range not working in thingiverse customizer atm [1:0.25:16]
 
-// supports for the stem, as it often comes off during printing. disabled by default, but highly reccommended.
+// Supports for the stem, as it often comes off during printing. disabled by default, but highly reccommended.
 $stem_support_type = "disable"; // [brim, tines, disabled]
-// the stem is the hardest part to print, so this variable controls how much 'slop' there is in the stem
-$stem_slop = 0.3; // not working in thingiverse customizer atm [0:0.01:1]
+// The stem is the hardest part to print, so this variable controls how much 'slop' there is in the stem
+$stem_slop = 0.3; // Not working in thingiverse customizer atm [0:0.01:1]
 
-// font size used for text
+// Font size used for text
 $font_size = 6;
 
-// invert dishing. mostly for spacebar
+// Invert dishing. mostly for spacebar
 $inverted_dish = false;
 
 // Enable stabilizers. If you don't want stabilizers use disable; most other keycaps use Cherry stabilizers
@@ -2097,80 +2097,80 @@ $stabilizer_type = "disable"; // [cherry, rounded_cherry, alps, disable]
 /* [Advanced] */
 
 /* Key */
-// height in units of key. should remain 1 for most uses
+// Height in units of key. should remain 1 for most uses
 $key_height = 1.0;
-// keytop thickness, aka how many millimeters between the inside and outside of the top surface of the key
+// Keytop thickness, aka how many millimeters between the inside and outside of the top surface of the key
 $keytop_thickness = 1;
-// wall thickness, aka the thickness of the sides of the keycap. note this is the total thickness, aka 3 = 1.5mm walls
+// Wall thickness, aka the thickness of the sides of the keycap. note this is the total thickness, aka 3 = 1.5mm walls
 $wall_thickness = 3;
-// radius of corners of keycap
+// Radius of corners of keycap
 $corner_radius = 1;
-// width of the very bottom of the key
+// Width of the very bottom of the key
 $bottom_key_width = 18.16;
-// height (from the front) of the very bottom of the key
+// Height (from the front) of the very bottom of the key
 $bottom_key_height = 18.16;
-// how much less width there is on the top. eg top_key_width = bottom_key_width - width_difference
+// How much less width there is on the top. eg top_key_width = bottom_key_width - width_difference
 $width_difference = 6;
-// how much less height there is on the top
+// How much less height there is on the top
 $height_difference = 4;
-// how deep the key is, before adding a dish
+// How deep the key is, before adding a dish
 $total_depth = 11.5;
-// the tilt of the dish in degrees. divided by key height
+// The tilt of the dish in degrees. divided by key height
 $top_tilt = -6;
-// how skewed towards the back the top is (0 for center)
+// How skewed towards the back the top is (0 for center)
 $top_skew = 1.7;
 
 /* Stem */
 
-// how far the throw distance of the switch is. determines how far the 'cross' in the cherry switch digs into the stem, and how long the keystem needs to be before supports can start. luckily, alps and cherries have a pretty similar throw. can modify to have stouter keycaps for low profile switches, etc
+// How far the throw distance of the switch is. determines how far the 'cross' in the cherry switch digs into the stem, and how long the keystem needs to be before supports can start. luckily, alps and cherries have a pretty similar throw. can modify to have stouter keycaps for low profile switches, etc
 $stem_throw = 4;
-// diameter of the outside of the rounded cherry stem
+// Diameter of the outside of the rounded cherry stem
 $rounded_cherry_stem_d = 5.5;
 
 
-// how much higher the stem is than the bottom of the keycap.
-// inset stem requires support but is more accurate in some profiles
+// How much higher the stem is than the bottom of the keycap.
+// Inset stem requires support but is more accurate in some profiles
 $stem_inset = 0;
-// how many degrees to rotate the stems. useful for sideways keycaps, maybe
+// How many degrees to rotate the stems. useful for sideways keycaps, maybe
 $stem_rotation = 0;
 
 /* Shape */
 
-// key shape type, determines the shape of the key. default is 'rounded square'
+// Key shape type, determines the shape of the key. default is 'rounded square'
 $key_shape_type = "rounded_square";
 // ISO enter needs to be linear extruded NOT from the center. this tells the program how far up 'not from the center' is
 $linear_extrude_height_adjustment = 0;
-// how many slices will be made, to approximate curves on corners. Leave at 1 if you are not curving corners
-// if you're doing fancy bowed keycap sides, this controls how many slices you take
+// How many slices will be made, to approximate curves on corners. Leave at 1 if you are not curving corners
+// If you're doing fancy bowed keycap sides, this controls how many slices you take
 $height_slices = 1;
 
 /* Dish */
 
-// what type of dish the key has. note that unlike stems and supports a dish ALWAYS gets rendered.
+// What type of dish the key has. note that unlike stems and supports a dish ALWAYS gets rendered.
 $dish_type = "cylindrical"; // [cylindrical, spherical, sideways cylindrical, old spherical, disable]
-// how deep the dish 'digs' into the top of the keycap. this is max depth, so you can't find the height from total_depth - dish_depth. besides the top is skewed anyways
+// How deep the dish 'digs' into the top of the keycap. this is max depth, so you can't find the height from total_depth - dish_depth. besides the top is skewed anyways
 $dish_depth = 1;
-// how skewed in the x direction the dish is
+// How skewed in the x direction the dish is
 $dish_skew_x = 0;
-// how skewed in the y direction (height) the dish is
+// How skewed in the y direction (height) the dish is
 $dish_skew_y = 0;
-// if you need the dish to extend further, you can 'overdraw' the rectangle it will hit
+// If you need the dish to extend further, you can 'overdraw' the rectangle it will hit
 $dish_overdraw_width = 0;
-// same as width but for height
+// Same as width but for height
 $dish_overdraw_height = 0;
 
 /* Misc */
-// there's a bevel on the cherry stems to aid insertion / guard against first layer squishing making a hard-to-fit stem.
+// There's a bevel on the cherry stems to aid insertion / guard against first layer squishing making a hard-to-fit stem.
 $cherry_bevel = true;
 
-// how tall in mm the stem support is, if there is any. stem support sits around the keystem and helps to secure it while printing.
+// How tall in mm the stem support is, if there is any. stem support sits around the keystem and helps to secure it while printing.
 $stem_support_height = 0.4;
-// font used for text
+// Font used for text
 $font="DejaVu Sans Mono:style=Book";
-// whether or not to render fake keyswitches to check clearances
+// Whether or not to render fake keyswitches to check clearances
 $clearance_check = false;
-// use linear_extrude instead of hull slices to make the shape of the key
-// should be faster, also required for concave shapes
+// Use linear_extrude instead of hull slices to make the shape of the key
+// Should be faster, also required for concave shapes
 $linear_extrude_shape = false;
 //should the key be rounded? unnecessary for most printers, and very slow
 $rounded_key = false;
@@ -2191,20 +2191,20 @@ $key_bump_edge = 0.4;
 //list of legends to place on a key format: [text, halign, valign, size]
 //halign = "left" or "center" or "right"
 //valign = "top" or "center" or "bottom"
-// currently does not work with thingiverse customizer, and actually breaks it
+// Currently does not work with thingiverse customizer, and actually breaks it
 $legends = [];
 
-// dimensions of alps stem
+// Dimensions of alps stem
 $alps_stem = [4.45, 2.25];
 
-// ternary is ONLY for customizer. it will NOT work if you're using this in
-// openSCAD, unless you're using the customizer. you should use stabilized() or
-// set the variable directly
-// array of positions of stabilizers
+// Ternary is ONLY for customizer. it will NOT work if you're using this in
+// OpenSCAD, unless you're using the customizer. you should use stabilized() or
+// Set the variable directly
+// Array of positions of stabilizers
 $stabilizers = $key_length > 5.75 ? [[-50, 0], [50, 0]] : [[-12,0],[12,0]];
 
-// where the stems are in relation to the center of the keycap, in units. default is one in the center
-// shouldn't work in thingiverse customizer, though it has been...
+// Where the stems are in relation to the center of the keycap, in units. default is one in the center
+// Shouldn't work in thingiverse customizer, though it has been...
 $stem_positions = [[0,0]];
   key();
 }

--- a/key/customizer_base.scad
+++ b/key/customizer_base.scad
@@ -1,6 +1,16 @@
 // entry point for customizer script. This probably isn't useful to most people,
 // as it's just a wrapper that helps generate customizer.scad for thingiverse.
 
+/* [Basic-Settings] */
+
+// what preset profile do you wish to use? disable if you are going to set paramters below
+key_profile = "dcs"; // [dcs, oem, dsa, sa, g20, disable]
+// what key profile row is this keycap on? 0 for disable
+row = 1; // [5,1,2,3,4,0]
+
+// What does the top of your key say?
+legend = "";
+
 include <src/settings.scad>
 
 include <src/key_sizes.scad>
@@ -10,4 +20,4 @@ include <src/key_transformations.scad>
 
 use <src/key.scad>
 
-key();
+key_profile(key_profile, row) legend(legend) key();

--- a/key/customizer_base.scad
+++ b/key/customizer_base.scad
@@ -1,0 +1,13 @@
+// entry point for customizer script. This probably isn't useful to most people,
+// as it's just a wrapper that helps generate customizer.scad for thingiverse.
+
+include <src/settings.scad>
+
+include <src/key_sizes.scad>
+include <src/key_profiles.scad>
+include <src/key_types.scad>
+include <src/key_transformations.scad>
+
+use <src/key.scad>
+
+key();

--- a/key/customizer_base.scad
+++ b/key/customizer_base.scad
@@ -20,4 +20,6 @@ include <src/key_transformations.scad>
 
 use <src/key.scad>
 
-key_profile(key_profile, row) legend(legend) key();
+key_profile(key_profile, row) legend(legend) {
+  key();
+}

--- a/key/expand.rb
+++ b/key/expand.rb
@@ -1,0 +1,27 @@
+
+def expand(filename)
+  lines = File.readlines(filename)
+  old_dir = Dir.getwd
+
+  Dir.chdir File.dirname(filename)
+  lines = lines.flat_map do |line|
+    if line =~ /(include|use)\s*<(.*)>/
+      # File.readlines("./#{$2}")
+      expand("./#{$2}")
+    # in lieu of actually implementing `use`, we can just cull this final line from key.scad
+    elsif line =~ /example\_key\(\);/
+      ""
+    else
+      line
+    end
+  end
+
+  Dir.chdir old_dir
+
+  lines
+end
+
+lines = expand(ARGV[1] || 'keys.scad')
+
+f = File.open('customizer.scad', 'w')
+f.write lines.join

--- a/key/expand.rb
+++ b/key/expand.rb
@@ -21,7 +21,7 @@ def expand(filename)
   lines
 end
 
-lines = expand(ARGV[1] || 'keys.scad')
+lines = expand(ARGV[1] || 'customizer_base.scad')
 
 f = File.open('customizer.scad', 'w')
 f.write lines.join

--- a/key/keys.scad
+++ b/key/keys.scad
@@ -13,33 +13,6 @@ include <src/key_profiles.scad>
 include <src/key_types.scad>
 include <src/key_transformations.scad>
 
-module translate_u(x=0, y=0, z=0){
-  translate([x * unit, y*unit, z*unit]) children();
-}
-
-// row 5 is commonly the top row, for whatever reason
-key_profiles = ["dcs", "oem", "sa", "g20", "dsa"];
-
-module one_single_key(profile, row, unsculpted) {
-   key_profile(profile, unsculpted ? 3 : row) cherry() key();
-}
-
-module one_row_profile(profile, unsculpted = false) {
-  rows = [5, 1, 2, 3, 4];
-  for(row = [0:len(rows)-1]) {
-    translate_u(0, -row) one_single_key(profile, rows[row], unsculpted);
-  }
-}
-
-for (p = [0:len(key_profiles)-1]) {
-  translate_u(p){
-    /* one_row_profile(key_profiles[p]); */
-  }
-}
-
-/* translate_u(0, 0) one_row_profile("oem"); */
-/* dsa_row(3) u(1) uh(1) cherry() key(); */
-
 translate_u(0, 0) sa_row(3) stepped_caps_lock() {
   key();
 }
@@ -53,6 +26,3 @@ translate_u(0, 2) sa_row(1) spacebar() alps() {
   $support_type = false;
   key();
 }
-
-/* sculpted_square_shape([19,19], [0,0], 0.3);
-translate([26,0,0]) rounded_square_shape([19,19], [0,0], 0.3); */

--- a/key/keys.scad
+++ b/key/keys.scad
@@ -15,7 +15,5 @@ include <src/key_transformations.scad>
 
 
 //$has_brim=true;
-sa_row(3) {
-  $stem_slop = 0;
+
    key();
-}

--- a/key/keys.scad
+++ b/key/keys.scad
@@ -13,16 +13,9 @@ include <src/key_profiles.scad>
 include <src/key_types.scad>
 include <src/key_transformations.scad>
 
-translate_u(0, 0) sa_row(3) stepped_caps_lock() {
-  key();
-}
 
-translate_u(0, 1) sa_row(2) lshift() {
-  $stem_type = false;
-  key();
-}
-
-translate_u(0, 2) sa_row(1) spacebar() alps() {
-  $support_type = false;
-  key();
+//$has_brim=true;
+sa_row(3) {
+  $stem_slop = 0;
+   key();
 }

--- a/key/src/dishes.scad
+++ b/key/src/dishes.scad
@@ -21,9 +21,9 @@ module  dish(width, height, depth, inverted) {
     }
     else if ($dish_type == "old spherical") {
       old_spherical_dish(width, height, depth, inverted);
+    } else if ($dish_type == "disable") {
+      // else no dish
     } else {
-      // else no dish, "no dish" is the value
-      // switchted to actually diffing a cube here due to changes to stems being differenced from the dish instead of the inside
-      translate([0,0,500]) cube([width, height, 1000], center=true);
+      echo("WARN: $dish_type unsupported");
     }
 }

--- a/key/src/functions.scad
+++ b/key/src/functions.scad
@@ -1,0 +1,25 @@
+// I use functions when I need to compute special variables off of other special variables
+// functions need to be explicitly included, unlike special variables, which
+// just need to have been set before they are used. hence this file
+
+// cherry stem dimensions
+function outer_cherry_stem(slop) = [7.2 - slop * 2, 5.5 - slop * 2];
+
+// box (kailh) switches have a bit less to work with
+function outer_box_cherry_stem(slop) = [6 - slop, 6 - slop];
+
+// .005 purely for aesthetics, to get rid of that ugly crosshatch
+function cherry_cross(slop, extra_vertical = 0) = [
+  // horizontal tine
+  [4.03 + slop, 1.15 + slop / 3],
+  // vertical tine
+  [1.25 + slop / 3, 4.23 + extra_vertical + slop / 3 + .005],
+];
+
+// actual mm key width and height
+function total_key_width(delta = 0) = $bottom_key_width + $unit * ($key_length - 1) - delta;
+function total_key_height(delta = 0) = $bottom_key_height + $unit * ($key_height - 1) - delta;
+
+// actual mm key width and height at the top
+function top_total_key_width() = $bottom_key_width + ($unit * ($key_length - 1)) - $width_difference;
+function top_total_key_height() = $bottom_key_height + ($unit * ($key_height - 1)) - $height_difference;

--- a/key/src/key.scad
+++ b/key/src/key.scad
@@ -135,13 +135,20 @@ module _dish() {
 
 // for when you want to take the dish out of things
 // used for adding the dish to the key shape and making sure stems don't stick out the top
+// has physical limits, since you can't specify planes in openscad
+// maybe I should make a bounding box cube, difference that with the dish then intersect with the children
 module dished(depth_difference, inverted = false) {
   difference() {
     children();
     top_placement(depth_difference){
       difference(){
         union() {
-          translate([-500, -500]) cube(1000);
+          // this weird math here is so Customizer doesn't see a giant shape and zoom out a million miles. could just be cube(1000)
+          translate([-$key_length * unit, -$key_height * unit]) cube([
+            $key_length*2 * unit,
+            $key_height*2 * unit,
+            50
+          ]);
           if (!inverted) _dish();
         }
         if (inverted) _dish();
@@ -154,7 +161,7 @@ module dished(depth_difference, inverted = false) {
 // more user-friendly than top_placement
 module top_of_key(){
   // if there is a dish, we need to account for how much it digs into the top
-  dish_depth = ($dish_type == "no dish") ? 0 : $dish_depth;
+  dish_depth = ($dish_type == "disable") ? 0 : $dish_depth;
   // if the dish is inverted, we need to account for that too. in this case we do half, otherwise the children would be floating on top of the dish
   corrected_dish_depth = ($inverted_dish) ? -dish_depth / 2 : dish_depth;
 
@@ -270,19 +277,19 @@ module key(inset = false) {
   }
 
   // both stem and support are optional
-  if ($stem_type || $stabilizer_type) {
+  if ($stem_type != "disable" || $stabilizer_type != "disable") {
     dished($keytop_thickness, $inverted_dish) {
       translate([0, 0, $stem_inset]) {
-        if ($stabilizer_type) stems_for($stabilizers, $stabilizer_type);
-        if ($stem_type) stems_for($stem_positions, $stem_type);
+        if ($stabilizer_type != "disable") stems_for($stabilizers, $stabilizer_type);
+        if ($stem_type != "disable") stems_for($stem_positions, $stem_type);
       }
     }
   }
 
-  if ($support_type){
+  if ($support_type != "disable"){
     inside() {
       translate([0, 0, $stem_inset]) {
-        if ($stabilizer_type) support_for($stabilizers, $stabilizer_type);
+        if ($stabilizer_type != "disable") support_for($stabilizers, $stabilizer_type);
 
         // always render stem support even if there isn't a stem.
         // rendering flat support w/no stem is much more common than a hollow keycap

--- a/key/src/key.scad
+++ b/key/src/key.scad
@@ -1,6 +1,8 @@
 // files
+include <functions.scad>
 include <shapes.scad>
 include <stems.scad>
+include <stem_supports.scad>
 include <dishes.scad>
 include <supports.scad>
 include <key_features.scad>
@@ -10,34 +12,23 @@ include <libraries/geodesic_sphere.scad>
 
 /* [Hidden] */
 $fs = .1;
-unit = 19.05;
-color1 = [.2667,.5882,1];
+$unit = 19.05;
+blue = [.2667,.5882,1];
 color2 = [.5412, .4784, 1];
-color3 = [.4078, .3569, .749];
-color4 = [1, .6941, .2];
+purple = [.4078, .3569, .749];
+yellow = [1, .6941, .2];
 transparent_red = [1,0,0, 0.15];
-
-// derived values. can't be variables if we want them to change when the special variables do
-
-// actual mm key width and height
-function total_key_width(delta = 0) = $bottom_key_width + unit * ($key_length - 1) - delta;
-function total_key_height(delta = 0) = $bottom_key_height + unit * ($key_height - 1) - delta;
-
-// actual mm key width and height at the top
-function top_total_key_width() = $bottom_key_width + (unit * ($key_length - 1)) - $width_difference;
-function top_total_key_height() = $bottom_key_height + (unit * ($key_height - 1)) - $height_difference;
-
 
 // key shape including dish. used as the ouside and inside shape in keytop(). allows for itself to be shrunk in depth and width / height
 module shape(thickness_difference, depth_difference){
   dished(depth_difference, $inverted_dish) {
-    color(color1) shape_hull(thickness_difference, depth_difference, 2);
+    color(blue) shape_hull(thickness_difference, depth_difference, 2);
   }
 }
 
 // shape of the key but with soft, rounded edges. much more realistic, MUCH more complex. orders of magnitude more complex
 module rounded_shape() {
-  color(color1) minkowski(){
+  color(blue) minkowski(){
     // half minkowski in the z direction
     shape($minkowski_radius * 2, $minkowski_radius/2);
     difference(){
@@ -130,7 +121,7 @@ module top_placement(depth_difference) {
 
 // just to DRY up the code
 module _dish() {
-  color(color3) dish(top_total_key_width() + $dish_overdraw_width, top_total_key_height() + $dish_overdraw_height, $dish_depth, $inverted_dish);
+  color(purple) dish(top_total_key_width() + $dish_overdraw_width, top_total_key_height() + $dish_overdraw_height, $dish_depth, $inverted_dish);
 }
 
 // for when you want to take the dish out of things
@@ -144,9 +135,9 @@ module dished(depth_difference, inverted = false) {
       difference(){
         union() {
           // this weird math here is so Customizer doesn't see a giant shape and zoom out a million miles. could just be cube(1000)
-          translate([-$key_length * unit, -$key_height * unit]) cube([
-            $key_length*2 * unit,
-            $key_height*2 * unit,
+          translate([-$key_length * $unit, -$key_height * $unit]) cube([
+            $key_length*2 * $unit,
+            $key_height*2 * $unit,
             50
           ]);
           if (!inverted) _dish();
@@ -192,13 +183,16 @@ module keystem_positions(positions) {
 
 module support_for(positions, stem_type) {
   keystem_positions(positions) {
-    color(color4) supports($support_type, stem_type, $stem_throw, $total_depth - $stem_throw);
+    color(yellow) supports($support_type, stem_type, $stem_throw, $total_depth - $stem_throw);
   }
 }
 
 module stems_for(positions, stem_type) {
   keystem_positions(positions) {
-    color(color4) stem(stem_type, $total_depth, $has_brim, $stem_slop);
+    color(yellow) stem(stem_type, $total_depth, $stem_slop);
+    if ($stem_support_type != "disable") {
+      color(color2) stem_support($stem_support_type, stem_type, $stem_support_height, $stem_slop);
+    }
   }
 }
 

--- a/key/src/key.scad
+++ b/key/src/key.scad
@@ -121,29 +121,42 @@ module top_placement(depth_difference) {
 
 // just to DRY up the code
 module _dish() {
-  color(purple) dish(top_total_key_width() + $dish_overdraw_width, top_total_key_height() + $dish_overdraw_height, $dish_depth, $inverted_dish);
+  dish(top_total_key_width() + $dish_overdraw_width, top_total_key_height() + $dish_overdraw_height, $dish_depth, $inverted_dish);
 }
+
+module envelope(depth_difference) {
+  s = 1.5;
+  hull(){
+    cube([total_key_width() * s, total_key_height() * s, 0.01], center = true);
+    top_placement(0.005 + depth_difference){
+      cube([top_total_key_width() * s, top_total_key_height() * s, 0.01], center = true);
+    }
+  }
+}
+
+module dished_for_show() {
+  difference(){
+    union() {
+      envelope();
+      if ($inverted_dish) top_placement(0) _dish();
+    }
+    if (!$inverted_dish) top_placement(0) _dish();
+  }
+}
+
 
 // for when you want to take the dish out of things
 // used for adding the dish to the key shape and making sure stems don't stick out the top
-// has physical limits, since you can't specify planes in openscad
-// maybe I should make a bounding box cube, difference that with the dish then intersect with the children
+// creates a bounding box 1.5 times larger in width and height than the keycap.
 module dished(depth_difference, inverted = false) {
-  difference() {
+  intersection() {
     children();
-    top_placement(depth_difference){
-      difference(){
-        union() {
-          // this weird math here is so Customizer doesn't see a giant shape and zoom out a million miles. could just be cube(1000)
-          translate([-$key_length * $unit, -$key_height * $unit]) cube([
-            $key_length*2 * $unit,
-            $key_height*2 * $unit,
-            50
-          ]);
-          if (!inverted) _dish();
-        }
-        if (inverted) _dish();
+    difference(){
+      union() {
+        envelope(depth_difference);
+        if (inverted) top_placement(depth_difference) _dish();
       }
+      if (!inverted) top_placement(depth_difference) _dish();
     }
   }
 }

--- a/key/src/key_profiles.scad
+++ b/key/src/key_profiles.scad
@@ -1,6 +1,7 @@
 // key profile definitions
 
-// unlike the other files with their own dedicated folders, this one doesn't need a selector. it just collects all the functions
+// unlike the other files with their own dedicated folders, this one doesn't
+// need a selector. I wrote one anyways for customizer support though
 include <key_profiles/dcs.scad>
 include <key_profiles/oem.scad>
 include <key_profiles/dsa.scad>

--- a/key/src/key_profiles.scad
+++ b/key/src/key_profiles.scad
@@ -20,5 +20,9 @@ module key_profile(key_profile_type, row) {
     sa_row(row) children();
   } else if (key_profile_type == "g20") {
     g20_row(row) children();
+  } else if (key_profile_type == "disable") {
+    children();
+  } else {
+    echo("Warning: unsupported key_profile_type");
   }
 }

--- a/key/src/key_profiles/dcs.scad
+++ b/key/src/key_profiles/dcs.scad
@@ -30,5 +30,7 @@ module dcs_row(n=1) {
     $total_depth = 6;
     $top_tilt = 16;
     children();
+  } else {
+    children();
   }
 }

--- a/key/src/key_profiles/dsa.scad
+++ b/key/src/key_profiles/dsa.scad
@@ -1,11 +1,9 @@
 module dsa_row(n=3) {
   $key_shape_type = "sculpted_square";
-  depth_raisers = [0, 3.5, 1, 0, 1, 3];
   $bottom_key_width = 18.24; // 18.4;
   $bottom_key_height = 18.24; // 18.4;
   $width_difference = 6; // 5.7;
   $height_difference = 6; // 5.7;
-  $total_depth = 8.1 + depth_raisers[n];
   $top_tilt = n == 5 ? -21 : (n-3) * 7;
   $top_skew = 0;
   $dish_type = "spherical";
@@ -18,5 +16,23 @@ module dsa_row(n=3) {
   // do you even minkowski bro
   $corner_radius = 0.25;
 
-  children();
+  depth_raisers = [0, 3.5, 1, 0, 1, 3];
+  if (n == 5) {
+    $total_depth = 8.1 + depth_raisers[n];
+    children();
+  } else if (n == 1) {
+    $total_depth = 8.1 + depth_raisers[n];
+    children();
+  } else if (n == 2) {
+    $total_depth = 8.1 + depth_raisers[n];
+    children();
+  } else if (n == 3) {
+    $total_depth = 8.1 + depth_raisers[n];
+    children();
+  } else if (n == 4) {
+    $total_depth = 8.1 + depth_raisers[n];
+    children();
+  } else {
+    children();
+  }
 }

--- a/key/src/key_profiles/g20.scad
+++ b/key/src/key_profiles/g20.scad
@@ -3,20 +3,39 @@ module g20_row(n=3) {
   $bottom_key_height = 18.16;
   $width_difference = 2;
   $height_difference = 2;
-  $total_depth = 6 + abs((n-3) * 0.5);
   $top_tilt = 2.5;
-  $top_tilt =  n == 5 ? -18.5 : (n-3) * 7 + 2.5;
   $top_skew = 0.75;
-  $dish_type = "no dish";
+  $dish_type = "disable";
   $dish_depth = 0;
   $dish_skew_x = 0;
   $dish_skew_y = 0;
   $minkowski_radius = 1.75;
-    $key_bump_depth = 0.6;
-    $key_bump_edge = 2;
+  $key_bump_depth = 0.6;
+  $key_bump_edge = 2;
   //also,
   $rounded_key = true;
 
-
-  children();
+  if (n == 5) {
+    $total_depth = 6 + abs((n-3) * 0.5);
+    $top_tilt =  -18.55;
+    children();
+  } else if (n == 1) {
+    $total_depth = 6 + abs((n-3) * 0.5);
+    $top_tilt = (n-3) * 7 + 2.5;
+    children();
+  } else if (n == 2) {
+    $total_depth = 6 + abs((n-3) * 0.5);
+    $top_tilt = (n-3) * 7 + 2.5;
+    children();
+  } else if (n == 3) {
+    $total_depth = 6 + abs((n-3) * 0.5);
+    $top_tilt = (n-3) * 7 + 2.5;
+    children();
+  } else if (n == 4) {
+    $total_depth = 6 + abs((n-3) * 0.5);
+    $top_tilt = (n-3) * 7 + 2.5;
+    children();
+  } else {
+    children();
+  }
 }

--- a/key/src/key_profiles/oem.scad
+++ b/key/src/key_profiles/oem.scad
@@ -30,5 +30,7 @@ module oem_row(n=1) {
     $total_depth = 9.25;
     $top_tilt = 10;
     children();
+  } else {
+    children();
   }
 }

--- a/key/src/key_profiles/sa.scad
+++ b/key/src/key_profiles/sa.scad
@@ -33,5 +33,7 @@ module sa_row(n=1) {
     $total_depth = 12.925;
     $top_tilt = 7;
     children();
+  } else {
+    children();
   }
 }

--- a/key/src/key_transformations.scad
+++ b/key/src/key_transformations.scad
@@ -7,9 +7,15 @@ module translate_u(x=0, y=0, z=0){
   translate([x * unit, y*unit, z*unit]) children();
 }
 
-module brimmed(height = 0.2) {
-  $has_brim = true;
-  $brim_height = height;
+module brimmed_stem_support(height = 0.4) {
+  $stem_support_type = "brim";
+  $stem_support_height = height;
+  children();
+}
+
+module tined_stem_support(height = 0.4) {
+  $stem_support_type = "tines";
+  $stem_support_height = height;
   children();
 }
 
@@ -49,7 +55,7 @@ module stabilized(mm=12, vertical = false, type="cherry") {
 }
 
 module dishless() {
-  $dish_type = "no dish";
+  $dish_type = "disable";
   children();
 }
 
@@ -64,7 +70,7 @@ module filled() {
 }
 
 module blank() {
-  $stem_type = "blank";
+  $stem_type = "disable";
   children();
 }
 
@@ -83,6 +89,12 @@ module alps(slop) {
 module rounded_cherry(slop) {
   $stem_slop = slop ? slop : $stem_slop;
   $stem_type = "rounded_cherry";
+  children();
+}
+
+module box_cherry(slop) {
+  $stem_slop = slop ? slop : $stem_slop;
+  $stem_type = "box_cherry";
   children();
 }
 

--- a/key/src/key_transformations.scad
+++ b/key/src/key_transformations.scad
@@ -82,7 +82,7 @@ module alps(slop) {
 
 module rounded_cherry(slop) {
   $stem_slop = slop ? slop : $stem_slop;
-  $stem_type = "cherry_rounded";
+  $stem_type = "rounded_cherry";
   children();
 }
 
@@ -111,4 +111,15 @@ module bump(depth=undef) {
     $key_bump = true;
     $key_bump_depth = depth == undef ? $key_bump_depth : depth;
     children();
+}
+
+module one_single_key(profile, row, unsculpted) {
+   key_profile(profile, unsculpted ? 3 : row) key();
+}
+
+module one_row_profile(profile, unsculpted = false) {
+  rows = [5, 1, 2, 3, 4];
+  for(row = [0:len(rows)-1]) {
+    translate_u(0, -row) one_single_key(profile, rows[row], unsculpted);
+  }
 }

--- a/key/src/key_types.scad
+++ b/key/src/key_types.scad
@@ -47,7 +47,7 @@ module iso_enter() {
   $key_shape_type = "iso_enter";
   $linear_extrude_shape = true;
   $linear_extrude_height_adjustment = 19.05 * 0.5;
-  // (unit_length(1.5) - unit_length(1.25)) / 2
+  // this equals (unit_length(1.5) - unit_length(1.25)) / 2
   $dish_overdraw_width = 2.38125;
 
 

--- a/key/src/settings.scad
+++ b/key/src/settings.scad
@@ -1,44 +1,32 @@
-/* [Key] */
+/* [Basic-Settings] */
 
-//length in units of key
+// what type of stem you want. Most people want Cherry.
+$stem_type = "cherry";  // [cherry, alps, rounded_cherry, filled, disable]
+
+// support type. default is "flared" for easy FDM printing. to disable pass false
+$support_type = "flared"; // [flared, bars, flat, disable]
+
+//length in units of key. A regular key is 1 unit; spacebar is usually 6.25
 $key_length = 1;
-//height in units of key. should remain 1 for most uses
-$key_height = 1;
-
-/* [Brim] */
 
 //print brim for connector to help with bed adhesion
 $has_brim = false;
-// how tall in mm the brim is, if there is one. brim sits around the keystem and helps to secure it while printing.
-$brim_height = 0.4;
-// what type of stem you want. To turn off stems pass false. "cherry", "alps", and "cherry_rounded" supported
 
-/* [Stem] */
-// What stem do you want to use?
-$stem_type = "cherry";  // [cherry, alps, rounded_cherry, filled]
-// how much higher the stem is than the bottom of the keycap.
-// inset stem requires support but is more accurate in some profiles
-$stem_inset = 0;
-// how many degrees to rotate the stems. useful for sideways keycaps, maybe
-$stem_rotation = 0;
 // the stem is the hardest part to print, so this variable controls how much 'slop' there is in the stem
 $stem_slop = 0.3;
-
-/* [Support] */
-
-// support type. default is "flared" for easy FDM printing. to disable pass false
-$support_type = "flared"; // [flared, bars, flat]
-
-/* [Misc] */
 
 // font size used for text
 $font_size = 6;
 
+// invert dishing. mostly for spacebar
+$inverted_dish = false;
 
-/* [Advanced Features] */
+
+/* [Advanced] */
 
 /* Key */
-
+// height in units of key. should remain 1 for most uses
+$key_height = 1;
 // keytop thickness, aka how many millimeters between the inside and outside of the top surface of the key
 $keytop_thickness = 1;
 // wall thickness, aka the thickness of the sides of the keycap. note this is the total thickness, aka 3 = 1.5mm walls
@@ -71,6 +59,12 @@ $rounded_cherry_stem_d = 5.5;
 // dimensions of alps stem
 $alps_stem = [4.45, 2.25];
 
+// how much higher the stem is than the bottom of the keycap.
+// inset stem requires support but is more accurate in some profiles
+$stem_inset = 0;
+// how many degrees to rotate the stems. useful for sideways keycaps, maybe
+$stem_rotation = 0;
+
 /* Stabilizers */
 
 // array of positions of stabilizers
@@ -92,15 +86,13 @@ $height_slices = 1;
 /* Dish */
 
 // what type of dish the key has. note that unlike stems and supports a dish ALWAYS gets rendered.
-$dish_type = "cylindrical"; // [cylindrical, spherical, sideways cylindrical, old spherical]
+$dish_type = "cylindrical"; // [cylindrical, spherical, sideways cylindrical, old spherical, disable]
 // how deep the dish 'digs' into the top of the keycap. this is max depth, so you can't find the height from total_depth - dish_depth. besides the top is skewed anyways
 $dish_depth = 1;
 // how skewed in the x direction the dish is
 $dish_skew_x = 0;
 // how skewed in the y direction (height) the dish is
 $dish_skew_y = 0;
-// invert dishing. mostly for spacebar
-$inverted_dish = false;
 // if you need the dish to extend further, you can 'overdraw' the rectangle it will hit
 $dish_overdraw_width = 0;
 // same as width but for height
@@ -108,6 +100,8 @@ $dish_overdraw_height = 0;
 
 /* Misc */
 
+// how tall in mm the brim is, if there is one. brim sits around the keystem and helps to secure it while printing.
+$brim_height = 0.4;
 // font used for text
 $font="DejaVu Sans Mono:style=Book";
 // whether or not to render fake keyswitches to check clearances

--- a/key/src/settings.scad
+++ b/key/src/settings.scad
@@ -1,18 +1,50 @@
+/* [Key] */
+
+//length in units of key
+$key_length = 1;
+//height in units of key. should remain 1 for most uses
+$key_height = 1;
+
+/* [Brim] */
+
+//print brim for connector to help with bed adhesion
+$has_brim = false;
+// how tall in mm the brim is, if there is one. brim sits around the keystem and helps to secure it while printing.
+$brim_height = 0.4;
+// what type of stem you want. To turn off stems pass false. "cherry", "alps", and "cherry_rounded" supported
+
+/* [Stem] */
+// What stem do you want to use?
+$stem_type = "cherry";  // [cherry, alps, rounded_cherry, filled]
+// how much higher the stem is than the bottom of the keycap.
+// inset stem requires support but is more accurate in some profiles
+$stem_inset = 0;
+// how many degrees to rotate the stems. useful for sideways keycaps, maybe
+$stem_rotation = 0;
+// the stem is the hardest part to print, so this variable controls how much 'slop' there is in the stem
+$stem_slop = 0.3;
+
+/* [Support] */
+
+// support type. default is "flared" for easy FDM printing. to disable pass false
+$support_type = "flared"; // [flared, bars, flat]
+
+/* [Misc] */
+
+// font size used for text
+$font_size = 6;
+
+
+/* [Advanced Features] */
+
+/* Key */
+
 // keytop thickness, aka how many millimeters between the inside and outside of the top surface of the key
 $keytop_thickness = 1;
 // wall thickness, aka the thickness of the sides of the keycap. note this is the total thickness, aka 3 = 1.5mm walls
 $wall_thickness = 3;
-//whether stabilizer connectors are enabled
-$stabilizers = false;
-// font used for text
-$font="DejaVu Sans Mono:style=Book";
-// font size used for text
-$font_size = 6;
-// whether or not to render fake keyswitches to check clearances
-$clearance_check = false;
-
-/* [Key profile] */
-
+// radius of corners of keycap
+$corner_radius = 1;
 // width of the very bottom of the key
 $bottom_key_width = 18.16;
 // height (from the front) of the very bottom of the ke
@@ -27,79 +59,68 @@ $total_depth = 11.5;
 $top_tilt = -6;
 // how skewed towards the back the top is (0 for center)
 $top_skew = 1.7;
+
+/* Stem */
+
+// where the stems are in relation to the center of the keycap, in units. default is one in the center
+$stem_positions = [[0,0]];
+// how far the throw distance of the switch is. determines how far the 'cross' in the cherry switch digs into the stem, and how long the keystem needs to be before supports can start. luckily, alps and cherries have a pretty similar throw. can modify to have stouter keycaps for low profile switches, etc
+$stem_throw = 4;
+// diameter of the outside of the rounded cherry stem
+$rounded_cherry_stem_d = 5.5;
+// dimensions of alps stem
+$alps_stem = [4.45, 2.25];
+
+/* Stabilizers */
+
+// array of positions of stabilizers
+$stabilizers = [[-50,0],[50,0]];
+// what type of stem you want for the stabilizers. false disables
+$stabilizer_type = false;
+
+
+/* Shape */
+
+// key shape type, determines the shape of the key. default is 'rounded square'
+$key_shape_type = "rounded_square";
+// ISO enter needs to be linear extruded NOT from the center. this tells the program how far up 'not from the center' is
+$linear_extrude_height_adjustment = 0;
+// how many slices will be made, to approximate curves on corners. Leave at 1 if you are not curving corners
+// if you're doing fancy bowed keycap sides, this controls how many slices you take
+$height_slices = 1;
+
+/* Dish */
+
 // what type of dish the key has. note that unlike stems and supports a dish ALWAYS gets rendered.
-$dish_type = "cylindrical";
+$dish_type = "cylindrical"; // [cylindrical, spherical, sideways cylindrical, old spherical]
 // how deep the dish 'digs' into the top of the keycap. this is max depth, so you can't find the height from total_depth - dish_depth. besides the top is skewed anyways
 $dish_depth = 1;
 // how skewed in the x direction the dish is
 $dish_skew_x = 0;
 // how skewed in the y direction (height) the dish is
 $dish_skew_y = 0;
-//length in units of key
-$key_length = 1;
-//height in units of key. should remain 1 for most uses
-$key_height = 1;
-//print brim for connector to help with bed adhesion
-$has_brim = false;
-//when $has_brim this is the height of the brim
-$brim_height = 0.2;
 // invert dishing. mostly for spacebar
 $inverted_dish = false;
-// array of positions of stabilizers
-// ternary is a bad hack to keep the stabilizers flag working
-$stabilizers = [[-50,0],[50,0]];
+// if you need the dish to extend further, you can 'overdraw' the rectangle it will hit
+$dish_overdraw_width = 0;
+// same as width but for height
+$dish_overdraw_height = 0;
+
+/* Misc */
+
+// font used for text
+$font="DejaVu Sans Mono:style=Book";
+// whether or not to render fake keyswitches to check clearances
+$clearance_check = false;
 // use linear_extrude instead of hull slices to make the shape of the key
 // should be faster, also required for concave shapes
 $linear_extrude_shape = false;
 //should the key be rounded? unnecessary for most printers, and very slow
 $rounded_key = false;
-// what type of stem you want. To turn off stems pass false. "cherry", "alps", and "cherry_rounded" supported
-$stem_type = "cherry";
-// where the stems are in relation to the center of the keycap, in units. default is one in the center
-$stem_positions = [[0,0]];
-// what type of stem you want for the stabilizers. false disables
-$stabilizer_type = false;
-// how much higher the stem is than the bottom of the keycap.
-// inset stem requires support but is more accurate in some profiles
-$stem_inset = 0;
-// how many degrees to rotate the stems. useful for sideways keycaps, maybe
-$stem_rotation = 0;
-// radius of corners of keycap
-$corner_radius = 1;
-// support type. default is "flared" for easy FDM printing. to disable pass false
-$support_type = "flared";
-// key shape type, determines the shape of the key. default is 'rounded square'
-$key_shape_type = "rounded_square";
-// ISO enter needs to be linear extruded NOT from the center. this tells the program how far up 'not from the center' is
-$linear_extrude_height_adjustment = 0;
-// if you need the dish to extend further, you can 'overdraw' the rectangle it will hit
-$dish_overdraw_width = 0;
-// same as width but for height
-$dish_overdraw_height = 0;
-// how many slices will be made, to approximate curves on corners. Leave at 1 if you are not curving corners
-// if you're doing fancy bowed keycap sides, this controls how many slices you take
-$height_slices = 1;
-
 //minkowski radius. radius of sphere used in minkowski sum for minkowski_key function. 1.75 for G20
 $minkowski_radius = .33;
 
-
-// [ Stem Variables ]
-
-
-// the stem is the hardest part to print, so this variable controls how much 'slop' there is in the stem
-$stem_slop = 0.3;
-
-// how tall in mm the brim is, if there is one. brim sits around the keystem and helps to secure it while printing.
-$brim_height = 0.4;
-// how far the throw distance of the switch is. determines how far the 'cross' in the cherry switch digs into the stem, and how long the keystem needs to be before supports can start. luckily, alps and cherries have a pretty similar throw. can modify to have stouter keycaps for low profile switches, etc
-$stem_throw = 4;
-
-// diameter of the outside of the rounded cherry stem
-$rounded_cherry_stem_d = 5.5;
-
-// dimensions of alps stem
-$alps_stem = [4.45, 2.25];
+/* Features */
 
 //list of legends to place on a key format: [text, halign, valign, size]
 //halign = "left" or "center" or "right"

--- a/key/src/settings.scad
+++ b/key/src/settings.scad
@@ -1,27 +1,26 @@
 /* [Basic-Settings] */
 
-// What type of stem you want. Most people want Cherry.
-$stem_type = "cherry";  // [cherry, alps, rounded_cherry, box_cherry, filled, disable]
-
-// Support type. default is "flared" for easy FDM printing; bars are more realistic, and flat could be for artisans
-$support_type = "flared"; // [flared, bars, flat, disable]
-
 // Length in units of key. A regular key is 1 unit; spacebar is usually 6.25
 $key_length = 1.0; // Range not working in thingiverse customizer atm [1:0.25:16]
 
-// Supports for the stem, as it often comes off during printing. disabled by default, but highly reccommended.
-$stem_support_type = "disable"; // [brim, tines, disabled]
+// What type of stem you want. Most people want Cherry.
+$stem_type = "cherry";  // [cherry, alps, rounded_cherry, box_cherry, filled, disable]
+
 // The stem is the hardest part to print, so this variable controls how much 'slop' there is in the stem
 $stem_slop = 0.3; // Not working in thingiverse customizer atm [0:0.01:1]
 
 // Font size used for text
 $font_size = 6;
 
-// Invert dishing. mostly for spacebar
+// Set this to true if you're making a spacebar!
 $inverted_dish = false;
 
-// Enable stabilizers. If you don't want stabilizers use disable; most other keycaps use Cherry stabilizers
-$stabilizer_type = "disable"; // [cherry, rounded_cherry, alps, disable]
+
+// Support type. default is "flared" for easy FDM printing; bars are more realistic, and flat could be for artisans
+$support_type = "flared"; // [flared, bars, flat, disable]
+
+// Supports for the stem, as it often comes off during printing. disabled by default, but highly reccommended.
+$stem_support_type = "disable"; // [tines, brim, disabled]
 
 /* [Advanced] */
 
@@ -126,11 +125,14 @@ $legends = [];
 // Dimensions of alps stem
 $alps_stem = [4.45, 2.25];
 
-// Ternary is ONLY for customizer. it will NOT work if you're using this in
-// OpenSCAD, unless you're using the customizer. you should use stabilized() or
-// Set the variable directly
+// Enable stabilizers. If you don't want stabilizers use disable; most other keycaps use Cherry stabilizers
+$stabilizer_type = "cherry"; // [cherry, rounded_cherry, alps, disable]
+
+// Ternaries are ONLY for customizer. they will NOT work if you're using this in
+// OpenSCAD. you should use stabilized(), openSCAD customizer,
+// or set $stabilizers directly
 // Array of positions of stabilizers
-$stabilizers = $key_length > 5.75 ? [[-50, 0], [50, 0]] : [[-12,0],[12,0]];
+$stabilizers = $key_length >= 6 ? [[-50, 0], [50, 0]] : $key_length >= 2 ? [[-12,0],[12,0]] : [];
 
 // Where the stems are in relation to the center of the keycap, in units. default is one in the center
 // Shouldn't work in thingiverse customizer, though it has been...

--- a/key/src/settings.scad
+++ b/key/src/settings.scad
@@ -36,7 +36,7 @@ $wall_thickness = 3;
 $corner_radius = 1;
 // width of the very bottom of the key
 $bottom_key_width = 18.16;
-// height (from the front) of the very bottom of the ke
+// height (from the front) of the very bottom of the key
 $bottom_key_height = 18.16;
 // how much less width there is on the top. eg top_key_width = bottom_key_width - width_difference
 $width_difference = 6;
@@ -51,28 +51,17 @@ $top_skew = 1.7;
 
 /* Stem */
 
-// where the stems are in relation to the center of the keycap, in units. default is one in the center
-$stem_positions = [[0,0]];
 // how far the throw distance of the switch is. determines how far the 'cross' in the cherry switch digs into the stem, and how long the keystem needs to be before supports can start. luckily, alps and cherries have a pretty similar throw. can modify to have stouter keycaps for low profile switches, etc
 $stem_throw = 4;
 // diameter of the outside of the rounded cherry stem
 $rounded_cherry_stem_d = 5.5;
-// dimensions of alps stem
-$alps_stem = [4.45, 2.25];
+
 
 // how much higher the stem is than the bottom of the keycap.
 // inset stem requires support but is more accurate in some profiles
 $stem_inset = 0;
 // how many degrees to rotate the stems. useful for sideways keycaps, maybe
 $stem_rotation = 0;
-
-/* Stabilizers */
-
-// ternary is ONLY for customizer. it will NOT work if you're using this in
-// openSCAD, unless you're using the customizer. you should use stabilized() or
-// set the variable directly
-// array of positions of stabilizers
-$stabilizers = $key_length > 5.75 ? [[-50, 0], [50, 0]] : [[-12,0],[12,0]];
 
 /* Shape */
 
@@ -119,13 +108,30 @@ $minkowski_radius = .33;
 
 /* Features */
 
-//list of legends to place on a key format: [text, halign, valign, size]
-//halign = "left" or "center" or "right"
-//valign = "top" or "center" or "bottom"
-$legends = [];
 //insert locating bump
 $key_bump = false;
 //height of the location bump from the top surface of the key
 $key_bump_depth = 0.5;
 //distance to move the bump from the front edge of the key
 $key_bump_edge = 0.4;
+
+/* [Hidden] */
+
+//list of legends to place on a key format: [text, halign, valign, size]
+//halign = "left" or "center" or "right"
+//valign = "top" or "center" or "bottom"
+// currently does not work with thingiverse customizer, and actually breaks it
+$legends = [];
+
+// dimensions of alps stem
+$alps_stem = [4.45, 2.25];
+
+// ternary is ONLY for customizer. it will NOT work if you're using this in
+// openSCAD, unless you're using the customizer. you should use stabilized() or
+// set the variable directly
+// array of positions of stabilizers
+$stabilizers = $key_length > 5.75 ? [[-50, 0], [50, 0]] : [[-12,0],[12,0]];
+
+// where the stems are in relation to the center of the keycap, in units. default is one in the center
+// shouldn't work in thingiverse customizer, though it has been...
+$stem_positions = [[0,0]];

--- a/key/src/settings.scad
+++ b/key/src/settings.scad
@@ -1,7 +1,7 @@
 /* [Basic-Settings] */
 
 // what type of stem you want. Most people want Cherry.
-$stem_type = "cherry";  // [cherry, alps, rounded_cherry, filled, disable]
+$stem_type = "cherry";  // [cherry, alps, rounded_cherry, box_cherry, filled, disable]
 
 // support type. default is "flared" for easy FDM printing; bars are more realistic, and flat could be for artisans
 $support_type = "flared"; // [flared, bars, flat, disable]
@@ -9,9 +9,8 @@ $support_type = "flared"; // [flared, bars, flat, disable]
 // length in units of key. A regular key is 1 unit; spacebar is usually 6.25
 $key_length = 1.0; // range not working in thingiverse customizer atm [1:0.25:16]
 
-// print brim for connector to help with bed adhesion
-$has_brim = false;
-
+// supports for the stem, as it often comes off during printing. disabled by default, but highly reccommended.
+$stem_support_type = "disable"; // [brim, tines, disabled]
 // the stem is the hardest part to print, so this variable controls how much 'slop' there is in the stem
 $stem_slop = 0.3; // not working in thingiverse customizer atm [0:0.01:1]
 
@@ -101,9 +100,11 @@ $dish_overdraw_width = 0;
 $dish_overdraw_height = 0;
 
 /* Misc */
+// there's a bevel on the cherry stems to aid insertion / guard against first layer squishing making a hard-to-fit stem.
+$cherry_bevel = true;
 
-// how tall in mm the brim is, if there is one. brim sits around the keystem and helps to secure it while printing.
-$brim_height = 0.4;
+// how tall in mm the stem support is, if there is any. stem support sits around the keystem and helps to secure it while printing.
+$stem_support_height = 0.4;
 // font used for text
 $font="DejaVu Sans Mono:style=Book";
 // whether or not to render fake keyswitches to check clearances

--- a/key/src/settings.scad
+++ b/key/src/settings.scad
@@ -1,23 +1,23 @@
 /* [Basic-Settings] */
 
-// what type of stem you want. Most people want Cherry.
+// What type of stem you want. Most people want Cherry.
 $stem_type = "cherry";  // [cherry, alps, rounded_cherry, box_cherry, filled, disable]
 
-// support type. default is "flared" for easy FDM printing; bars are more realistic, and flat could be for artisans
+// Support type. default is "flared" for easy FDM printing; bars are more realistic, and flat could be for artisans
 $support_type = "flared"; // [flared, bars, flat, disable]
 
-// length in units of key. A regular key is 1 unit; spacebar is usually 6.25
-$key_length = 1.0; // range not working in thingiverse customizer atm [1:0.25:16]
+// Length in units of key. A regular key is 1 unit; spacebar is usually 6.25
+$key_length = 1.0; // Range not working in thingiverse customizer atm [1:0.25:16]
 
-// supports for the stem, as it often comes off during printing. disabled by default, but highly reccommended.
+// Supports for the stem, as it often comes off during printing. disabled by default, but highly reccommended.
 $stem_support_type = "disable"; // [brim, tines, disabled]
-// the stem is the hardest part to print, so this variable controls how much 'slop' there is in the stem
-$stem_slop = 0.3; // not working in thingiverse customizer atm [0:0.01:1]
+// The stem is the hardest part to print, so this variable controls how much 'slop' there is in the stem
+$stem_slop = 0.3; // Not working in thingiverse customizer atm [0:0.01:1]
 
-// font size used for text
+// Font size used for text
 $font_size = 6;
 
-// invert dishing. mostly for spacebar
+// Invert dishing. mostly for spacebar
 $inverted_dish = false;
 
 // Enable stabilizers. If you don't want stabilizers use disable; most other keycaps use Cherry stabilizers
@@ -26,80 +26,80 @@ $stabilizer_type = "disable"; // [cherry, rounded_cherry, alps, disable]
 /* [Advanced] */
 
 /* Key */
-// height in units of key. should remain 1 for most uses
+// Height in units of key. should remain 1 for most uses
 $key_height = 1.0;
-// keytop thickness, aka how many millimeters between the inside and outside of the top surface of the key
+// Keytop thickness, aka how many millimeters between the inside and outside of the top surface of the key
 $keytop_thickness = 1;
-// wall thickness, aka the thickness of the sides of the keycap. note this is the total thickness, aka 3 = 1.5mm walls
+// Wall thickness, aka the thickness of the sides of the keycap. note this is the total thickness, aka 3 = 1.5mm walls
 $wall_thickness = 3;
-// radius of corners of keycap
+// Radius of corners of keycap
 $corner_radius = 1;
-// width of the very bottom of the key
+// Width of the very bottom of the key
 $bottom_key_width = 18.16;
-// height (from the front) of the very bottom of the key
+// Height (from the front) of the very bottom of the key
 $bottom_key_height = 18.16;
-// how much less width there is on the top. eg top_key_width = bottom_key_width - width_difference
+// How much less width there is on the top. eg top_key_width = bottom_key_width - width_difference
 $width_difference = 6;
-// how much less height there is on the top
+// How much less height there is on the top
 $height_difference = 4;
-// how deep the key is, before adding a dish
+// How deep the key is, before adding a dish
 $total_depth = 11.5;
-// the tilt of the dish in degrees. divided by key height
+// The tilt of the dish in degrees. divided by key height
 $top_tilt = -6;
-// how skewed towards the back the top is (0 for center)
+// How skewed towards the back the top is (0 for center)
 $top_skew = 1.7;
 
 /* Stem */
 
-// how far the throw distance of the switch is. determines how far the 'cross' in the cherry switch digs into the stem, and how long the keystem needs to be before supports can start. luckily, alps and cherries have a pretty similar throw. can modify to have stouter keycaps for low profile switches, etc
+// How far the throw distance of the switch is. determines how far the 'cross' in the cherry switch digs into the stem, and how long the keystem needs to be before supports can start. luckily, alps and cherries have a pretty similar throw. can modify to have stouter keycaps for low profile switches, etc
 $stem_throw = 4;
-// diameter of the outside of the rounded cherry stem
+// Diameter of the outside of the rounded cherry stem
 $rounded_cherry_stem_d = 5.5;
 
 
-// how much higher the stem is than the bottom of the keycap.
-// inset stem requires support but is more accurate in some profiles
+// How much higher the stem is than the bottom of the keycap.
+// Inset stem requires support but is more accurate in some profiles
 $stem_inset = 0;
-// how many degrees to rotate the stems. useful for sideways keycaps, maybe
+// How many degrees to rotate the stems. useful for sideways keycaps, maybe
 $stem_rotation = 0;
 
 /* Shape */
 
-// key shape type, determines the shape of the key. default is 'rounded square'
+// Key shape type, determines the shape of the key. default is 'rounded square'
 $key_shape_type = "rounded_square";
 // ISO enter needs to be linear extruded NOT from the center. this tells the program how far up 'not from the center' is
 $linear_extrude_height_adjustment = 0;
-// how many slices will be made, to approximate curves on corners. Leave at 1 if you are not curving corners
-// if you're doing fancy bowed keycap sides, this controls how many slices you take
+// How many slices will be made, to approximate curves on corners. Leave at 1 if you are not curving corners
+// If you're doing fancy bowed keycap sides, this controls how many slices you take
 $height_slices = 1;
 
 /* Dish */
 
-// what type of dish the key has. note that unlike stems and supports a dish ALWAYS gets rendered.
+// What type of dish the key has. note that unlike stems and supports a dish ALWAYS gets rendered.
 $dish_type = "cylindrical"; // [cylindrical, spherical, sideways cylindrical, old spherical, disable]
-// how deep the dish 'digs' into the top of the keycap. this is max depth, so you can't find the height from total_depth - dish_depth. besides the top is skewed anyways
+// How deep the dish 'digs' into the top of the keycap. this is max depth, so you can't find the height from total_depth - dish_depth. besides the top is skewed anyways
 $dish_depth = 1;
-// how skewed in the x direction the dish is
+// How skewed in the x direction the dish is
 $dish_skew_x = 0;
-// how skewed in the y direction (height) the dish is
+// How skewed in the y direction (height) the dish is
 $dish_skew_y = 0;
-// if you need the dish to extend further, you can 'overdraw' the rectangle it will hit
+// If you need the dish to extend further, you can 'overdraw' the rectangle it will hit
 $dish_overdraw_width = 0;
-// same as width but for height
+// Same as width but for height
 $dish_overdraw_height = 0;
 
 /* Misc */
-// there's a bevel on the cherry stems to aid insertion / guard against first layer squishing making a hard-to-fit stem.
+// There's a bevel on the cherry stems to aid insertion / guard against first layer squishing making a hard-to-fit stem.
 $cherry_bevel = true;
 
-// how tall in mm the stem support is, if there is any. stem support sits around the keystem and helps to secure it while printing.
+// How tall in mm the stem support is, if there is any. stem support sits around the keystem and helps to secure it while printing.
 $stem_support_height = 0.4;
-// font used for text
+// Font used for text
 $font="DejaVu Sans Mono:style=Book";
-// whether or not to render fake keyswitches to check clearances
+// Whether or not to render fake keyswitches to check clearances
 $clearance_check = false;
-// use linear_extrude instead of hull slices to make the shape of the key
-// should be faster, also required for concave shapes
+// Use linear_extrude instead of hull slices to make the shape of the key
+// Should be faster, also required for concave shapes
 $linear_extrude_shape = false;
 //should the key be rounded? unnecessary for most printers, and very slow
 $rounded_key = false;
@@ -120,18 +120,18 @@ $key_bump_edge = 0.4;
 //list of legends to place on a key format: [text, halign, valign, size]
 //halign = "left" or "center" or "right"
 //valign = "top" or "center" or "bottom"
-// currently does not work with thingiverse customizer, and actually breaks it
+// Currently does not work with thingiverse customizer, and actually breaks it
 $legends = [];
 
-// dimensions of alps stem
+// Dimensions of alps stem
 $alps_stem = [4.45, 2.25];
 
-// ternary is ONLY for customizer. it will NOT work if you're using this in
-// openSCAD, unless you're using the customizer. you should use stabilized() or
-// set the variable directly
-// array of positions of stabilizers
+// Ternary is ONLY for customizer. it will NOT work if you're using this in
+// OpenSCAD, unless you're using the customizer. you should use stabilized() or
+// Set the variable directly
+// Array of positions of stabilizers
 $stabilizers = $key_length > 5.75 ? [[-50, 0], [50, 0]] : [[-12,0],[12,0]];
 
-// where the stems are in relation to the center of the keycap, in units. default is one in the center
-// shouldn't work in thingiverse customizer, though it has been...
+// Where the stems are in relation to the center of the keycap, in units. default is one in the center
+// Shouldn't work in thingiverse customizer, though it has been...
 $stem_positions = [[0,0]];

--- a/key/src/settings.scad
+++ b/key/src/settings.scad
@@ -3,17 +3,17 @@
 // what type of stem you want. Most people want Cherry.
 $stem_type = "cherry";  // [cherry, alps, rounded_cherry, filled, disable]
 
-// support type. default is "flared" for easy FDM printing. to disable pass false
+// support type. default is "flared" for easy FDM printing; bars are more realistic, and flat could be for artisans
 $support_type = "flared"; // [flared, bars, flat, disable]
 
-//length in units of key. A regular key is 1 unit; spacebar is usually 6.25
-$key_length = 1;
+// length in units of key. A regular key is 1 unit; spacebar is usually 6.25
+$key_length = 1.0; // range not working in thingiverse customizer atm [1:0.25:16]
 
-//print brim for connector to help with bed adhesion
+// print brim for connector to help with bed adhesion
 $has_brim = false;
 
 // the stem is the hardest part to print, so this variable controls how much 'slop' there is in the stem
-$stem_slop = 0.3;
+$stem_slop = 0.3; // not working in thingiverse customizer atm [0:0.01:1]
 
 // font size used for text
 $font_size = 6;
@@ -21,12 +21,14 @@ $font_size = 6;
 // invert dishing. mostly for spacebar
 $inverted_dish = false;
 
+// Enable stabilizers. If you don't want stabilizers use disable; most other keycaps use Cherry stabilizers
+$stabilizer_type = "disable"; // [cherry, rounded_cherry, alps, disable]
 
 /* [Advanced] */
 
 /* Key */
 // height in units of key. should remain 1 for most uses
-$key_height = 1;
+$key_height = 1.0;
 // keytop thickness, aka how many millimeters between the inside and outside of the top surface of the key
 $keytop_thickness = 1;
 // wall thickness, aka the thickness of the sides of the keycap. note this is the total thickness, aka 3 = 1.5mm walls
@@ -67,11 +69,11 @@ $stem_rotation = 0;
 
 /* Stabilizers */
 
+// ternary is ONLY for customizer. it will NOT work if you're using this in
+// openSCAD, unless you're using the customizer. you should use stabilized() or
+// set the variable directly
 // array of positions of stabilizers
-$stabilizers = [[-50,0],[50,0]];
-// what type of stem you want for the stabilizers. false disables
-$stabilizer_type = false;
-
+$stabilizers = $key_length > 5.75 ? [[-50, 0], [50, 0]] : [[-12,0],[12,0]];
 
 /* Shape */
 

--- a/key/src/stem_supports.scad
+++ b/key/src/stem_supports.scad
@@ -1,0 +1,16 @@
+include <stem_supports/brim.scad>
+include <stem_supports/tines.scad>
+
+
+//whole stem, alps or cherry, trimmed to fit
+module stem_support(support_type, stem_type, stem_support_height, slop){
+    if (support_type == "brim") {
+      brim_support(stem_type, stem_support_height, slop);
+    } else if (support_type == "tines") {
+      tines_support(stem_type, stem_support_height, slop);
+    } else if (support_type == "disable") {
+      children();
+    } else {
+      echo("Warning: unsupported $stem_support_type");
+    }
+}

--- a/key/src/stem_supports/brim.scad
+++ b/key/src/stem_supports/brim.scad
@@ -1,0 +1,37 @@
+include <../functions.scad>
+include <../stems/cherry.scad>
+
+module brim_support(stem_type, stem_support_height, slop) {
+  if(stem_type == "alps") {
+    linear_extrude(height=stem_support_height) {
+      offset(r=1){
+        square($alps_stem + [2,2], center=true);
+      }
+    }
+  } else if (stem_type == "cherry") {
+    difference() {
+      linear_extrude(height = stem_support_height){
+        offset(r=1){
+          square(outer_cherry_stem(slop) + [2,2], center=true);
+        }
+      }
+
+      inside_cherry_cross(slop);
+    }
+  } else if (stem_type == "rounded_cherry") {
+    difference() {
+      cylinder(d=$rounded_cherry_stem_d * 2, h=stem_support_height);
+      inside_cherry_cross(slop);
+    }
+  } else if (stem_type == "box_cherry") {
+    difference() {
+      linear_extrude(height = stem_support_height){
+        offset(r=1){
+          square(outer_box_cherry_stem(slop) + [2,2], center=true);
+        }
+      }
+
+      inside_cherry_cross(slop);
+    }
+  }
+}

--- a/key/src/stem_supports/tines.scad
+++ b/key/src/stem_supports/tines.scad
@@ -1,5 +1,5 @@
 include <../functions.scad>
-include <../cherry.scad>
+include <../stems/cherry.scad>
 
 module centered_tines(stem_support_height) {
   translate([0,0,$stem_support_height / 2]) cube([total_key_width($wall_thickness), 1, $stem_support_height], center = true);

--- a/key/src/stem_supports/tines.scad
+++ b/key/src/stem_supports/tines.scad
@@ -1,0 +1,35 @@
+include <../functions.scad>
+include <../cherry.scad>
+
+module centered_tines(stem_support_height) {
+  translate([0,0,$stem_support_height / 2]) cube([total_key_width($wall_thickness), 1, $stem_support_height], center = true);
+  translate([0,0,$stem_support_height / 2]) cube([1, total_key_height($wall_thickness), $stem_support_height], center = true);
+}
+
+module tines_support(stem_type, stem_support_height, slop) {
+  if (stem_type == "cherry") {
+    difference () {
+      union() {
+        translate([0,0,$stem_support_height / 2]) cube([total_key_width($wall_thickness), 1, $stem_support_height], center = true);
+        translate([2,0,$stem_support_height / 2]) cube([1, total_key_height($wall_thickness), $stem_support_height], center = true);
+        translate([-2,0,$stem_support_height / 2]) cube([1, total_key_height($wall_thickness), $stem_support_height], center = true);
+      }
+
+      inside_cherry_cross(slop);
+    }
+  } else if (stem_type == "box_cherry") {
+    difference () {
+      centered_tines(stem_support_height);
+
+      inside_cherry_cross(slop);
+    }
+  } else if (stem_type == "rounded_cherry") {
+    difference () {
+      centered_tines(stem_support_height);
+
+      inside_cherry_cross(slop);
+    }
+  } else if (stem_type == "alps"){
+    centered_tines(stem_support_height);
+  }
+}

--- a/key/src/stems.scad
+++ b/key/src/stems.scad
@@ -14,6 +14,8 @@ module stem(stem_type, depth, has_brim, slop){
       cherry_stem(depth, has_brim, slop);
     } else if (stem_type == "filled") {
       filled_stem();
+    } else if (stem_type == "disable") {
+      children();
     } else {
       echo("Warning: unsupported $stem_type");
     }

--- a/key/src/stems.scad
+++ b/key/src/stems.scad
@@ -1,17 +1,20 @@
 include <stems/cherry.scad>
 include <stems/rounded_cherry.scad>
+include <stems/box_cherry.scad>
 include <stems/alps.scad>
 include <stems/filled.scad>
 
 
 //whole stem, alps or cherry, trimmed to fit
-module stem(stem_type, depth, has_brim, slop){
+module stem(stem_type, depth, slop){
     if (stem_type == "alps") {
-      alps_stem(depth, has_brim, slop);
-    } else if (stem_type == "rounded_cherry") {
-      rounded_cherry_stem(depth, has_brim, slop);
+      alps_stem(depth, slop);
     } else if (stem_type == "cherry") {
-      cherry_stem(depth, has_brim, slop);
+      cherry_stem(depth, slop);
+    } else if (stem_type == "rounded_cherry") {
+      rounded_cherry_stem(depth, slop);
+    } else if (stem_type == "box_cherry") {
+      box_cherry_stem(depth, slop);
     } else if (stem_type == "filled") {
       filled_stem();
     } else if (stem_type == "disable") {

--- a/key/src/stems.scad
+++ b/key/src/stems.scad
@@ -8,7 +8,7 @@ include <stems/filled.scad>
 module stem(stem_type, depth, has_brim, slop){
     if (stem_type == "alps") {
       alps_stem(depth, has_brim, slop);
-    } else if (stem_type == "cherry_rounded") {
+    } else if (stem_type == "rounded_cherry") {
       rounded_cherry_stem(depth, has_brim, slop);
     } else if (stem_type == "cherry") {
       cherry_stem(depth, has_brim, slop);

--- a/key/src/stems/alps.scad
+++ b/key/src/stems/alps.scad
@@ -1,11 +1,4 @@
 module alps_stem(depth, has_brim, slop){
-  if(has_brim) {
-    linear_extrude(height=$brim_height) {
-      offset(r=1){
-        square($alps_stem + [2,2], center=true);
-      }
-    }
-  }
   linear_extrude(height=depth) {
     square($alps_stem, center = true);
   }

--- a/key/src/stems/box_cherry.scad
+++ b/key/src/stems/box_cherry.scad
@@ -1,0 +1,16 @@
+include <../functions.scad>
+include <cherry.scad>
+
+module box_cherry_stem(depth, slop) {
+  difference(){
+    // outside shape
+    linear_extrude(height = depth) {
+      offset(r=1){
+        square(outer_box_cherry_stem(slop) - [2,2], center=true);
+      }
+    }
+
+    // inside cross
+    inside_cherry_cross(slop);
+  }
+}

--- a/key/src/stems/cherry.scad
+++ b/key/src/stems/cherry.scad
@@ -6,7 +6,7 @@ function cherry_cross(slop) = [
   // horizontal tine
   [4.03 + slop, 1.15 + slop / 3],
   // vertical tine
-  [1.25 + slop / 3, 5.5 - slop * 2 + .005],
+  [1.25 + slop / 3, 4.9 + slop / 3 + .005],
 ];
 
 module cherry_stem(depth, has_brim, slop) {

--- a/key/src/stems/cherry.scad
+++ b/key/src/stems/cherry.scad
@@ -1,46 +1,37 @@
-// cherry stem dimensions
-function outer_cherry_stem(slop) = [7.2 - slop * 2, 5.5 - slop * 2];
+include <../functions.scad>
 
-// .005 purely for aesthetics, to get rid of that ugly crosshatch
-function cherry_cross(slop) = [
-  // horizontal tine
-  [4.03 + slop, 1.15 + slop / 3],
-  // vertical tine
-  [1.25 + slop / 3, 4.9 + slop / 3 + .005],
-];
+// extra length to the vertical tine of the inside cherry cross
+// splits the stem into halves - allows easier fitment
+extra_vertical = 0.6;
 
-module cherry_stem(depth, has_brim, slop) {
+module inside_cherry_cross(slop) {
+  // inside cross
+  // translation purely for aesthetic purposes, to get rid of that awful lattice
+  translate([0,0,-0.005]) {
+    linear_extrude(height = $stem_throw) {
+      square(cherry_cross(slop, extra_vertical)[0], center=true);
+      square(cherry_cross(slop, extra_vertical)[1], center=true);
+    }
+  }
+
+  // Guides to assist insertion and mitigate first layer squishing
+  if ($cherry_bevel){
+    for (i = cherry_cross(slop, extra_vertical)) hull() {
+      linear_extrude(height = 0.01, center = false) offset(delta = 0.4) square(i, center=true);
+      translate([0, 0, 0.5]) linear_extrude(height = 0.01, center = false)  square(i, center=true);
+    }
+  }
+}
+
+module cherry_stem(depth, slop) {
   difference(){
-    union() {
-      // outside shape
-      linear_extrude(height = depth) {
-        offset(r=1){
-          square(outer_cherry_stem(slop) - [2,2], center=true);
-        }
-      }
-
-      // brim, if applicable
-      if(has_brim) {
-        linear_extrude(height = $brim_height){
-          offset(r=1){
-            square(outer_cherry_stem(slop) + [2,2], center=true);
-          }
-        }
+    // outside shape
+    linear_extrude(height = depth) {
+      offset(r=1){
+        square(outer_cherry_stem(slop) - [2,2], center=true);
       }
     }
 
-    // inside cross
-    // translation purely for aesthetic purposes, to get rid of that awful lattice
-    translate([0,0,-0.005]) {
-      linear_extrude(height = $stem_throw) {
-        square(cherry_cross(slop)[0], center=true);
-        square(cherry_cross(slop)[1], center=true);
-      }
-      // Guides to assist insertion and mitigate first layer squishing
-      for (i = cherry_cross(slop)) hull() {
-        linear_extrude(height = 0.01, center = false) offset(delta = 0.4) square(i, center=true);
-        translate([0, 0, 0.5]) linear_extrude(height = 0.01, center = false)  square(i, center=true);
-      }
-    }
+    inside_cherry_cross(slop);
   }
 }

--- a/key/src/stems/filled.scad
+++ b/key/src/stems/filled.scad
@@ -5,5 +5,5 @@ module filled_stem() {
   // cube. shape() works but means that you certainly couldn't render this
   // stem without the presence of the entire library
 
-  shape();
+  shape($wall_thickness);
 }

--- a/key/src/stems/rounded_cherry.scad
+++ b/key/src/stems/rounded_cherry.scad
@@ -1,27 +1,12 @@
-// .005 purely for aesthetics, to get rid of that ugly crosshatch
-function cherry_cross(slop) = [
-  // horizontal tine
-  [4.03 + slop, 1.15 + slop / 3],
-  // vertical tine. can't really afford much slop
-  [1.25 + slop / 3, 4.9 + slop / 6 + .005],
-];
+include <../functions.scad>
+include <cherry.scad>
 
-module rounded_cherry_stem(depth, has_brim, slop) {
+module rounded_cherry_stem(depth, slop) {
   difference(){
-    union(){
-      cylinder(d=$rounded_cherry_stem_d, h=depth);
-      if(has_brim) {
-        cylinder(d=$rounded_cherry_stem_d * 2, h=$brim_height);
-      }
-    }
+    cylinder(d=$rounded_cherry_stem_d, h=depth);
 
     // inside cross
     // translation purely for aesthetic purposes, to get rid of that awful lattice
-    translate([0,0,-0.005]) {
-      linear_extrude(height = $stem_throw) {
-        square(cherry_cross(slop)[0], center=true);
-        square(cherry_cross(slop)[1], center=true);
-      }
-    }
+    inside_cherry_cross(slop);
   }
 }

--- a/key/src/stems/rounded_cherry.scad
+++ b/key/src/stems/rounded_cherry.scad
@@ -2,8 +2,8 @@
 function cherry_cross(slop) = [
   // horizontal tine
   [4.03 + slop, 1.15 + slop / 3],
-  // vertical tine
-  [1.25 + slop / 3, 5.5 - slop * 2 + .005],
+  // vertical tine. can't really afford much slop
+  [1.25 + slop / 3, 4.9 + slop / 6 + .005],
 ];
 
 module rounded_cherry_stem(depth, has_brim, slop) {

--- a/key/src/supports.scad
+++ b/key/src/supports.scad
@@ -4,11 +4,11 @@ include <supports/bars.scad>
 
 module supports(type, stem_type, loft, height) {
   if (type == "flared") {
-    flared_support(stem_type, loft, height);
+    flared(stem_type, loft, height);
   } else if (type == "flat") {
-    flat_support(stem_type, loft, height);
+    flat(stem_type, loft, height);
   } else if (type == "bars") {
-    bars_support(stem_type, loft, height);
+    bars(stem_type, loft, height);
   } else {
     echo("Warning: unsupported $support_type");
   }

--- a/key/src/supports.scad
+++ b/key/src/supports.scad
@@ -9,6 +9,8 @@ module supports(type, stem_type, loft, height) {
     flat(stem_type, loft, height);
   } else if (type == "bars") {
     bars(stem_type, loft, height);
+  } else if (type == "disable") {
+    children();
   } else {
     echo("Warning: unsupported $support_type");
   }

--- a/key/src/supports/bars.scad
+++ b/key/src/supports/bars.scad
@@ -1,4 +1,4 @@
-module bars_support(stem_type, loft, height) {
+module bars(stem_type, loft, height) {
   translate([0,0,loft + height / 2]){
     cube([2, 100, height], center = true);
     cube([100, 2, height], center = true);

--- a/key/src/supports/flared.scad
+++ b/key/src/supports/flared.scad
@@ -1,6 +1,4 @@
-// cherry stem dimensions
-// don't wanna introduce slop here so $stem_slop it is I guess
-function outer_cherry_stem() = [7.2 - $stem_slop * 2, 5.5 - $stem_slop * 2];
+include <../functions.scad>
 
 // figures out the scale factor needed to make a 45 degree wall
 function scale_for_45(height, starting_size) = (height * 2 + starting_size) / starting_size;
@@ -18,13 +16,22 @@ module flared(stem_type, loft, height) {
       linear_extrude(height=height, scale = alps_scale){
         square($alps_stem, center=true);
       }
+    } else if (stem_type == "box_cherry") {
+      // always render cherry if no stem type. this includes stem_type = false!
+      // this avoids a bug where the keycap is rendered filled when not desired
+      cherry_scale = [scale_for_45(height, outer_box_cherry_stem($stem_slop)[0]), scale_for_45(height, outer_box_cherry_stem($stem_slop)[1])];
+      linear_extrude(height=height, scale = cherry_scale){
+        offset(r=1){
+          square(outer_box_cherry_stem($stem_slop) - [2,2], center=true);
+        }
+      }
     } else {
       // always render cherry if no stem type. this includes stem_type = false!
       // this avoids a bug where the keycap is rendered filled when not desired
-      cherry_scale = [scale_for_45(height, outer_cherry_stem()[0]), scale_for_45(height, outer_cherry_stem()[1])];
+      cherry_scale = [scale_for_45(height, outer_cherry_stem($stem_slop)[0]), scale_for_45(height, outer_cherry_stem($stem_slop)[1])];
       linear_extrude(height=height, scale = cherry_scale){
         offset(r=1){
-          square(outer_cherry_stem() - [2,2], center=true);
+          square(outer_cherry_stem($stem_slop) - [2,2], center=true);
         }
       }
     }

--- a/key/src/supports/flared.scad
+++ b/key/src/supports/flared.scad
@@ -9,7 +9,7 @@ function scale_for_45(height, starting_size) = (height * 2 + starting_size) / st
 // also kind of messy... oh well
 module flared(stem_type, loft, height) {
   translate([0,0,loft]){
-    if (stem_type == "cherry_rounded") {
+    if (stem_type == "rounded_cherry") {
       linear_extrude(height=height, scale = scale_for_45(height, $rounded_cherry_stem_d)){
         circle(d=$rounded_cherry_stem_d);
       }

--- a/key/src/supports/flared.scad
+++ b/key/src/supports/flared.scad
@@ -7,7 +7,7 @@ function scale_for_45(height, starting_size) = (height * 2 + starting_size) / st
 
 // complicated since we want the different stems to work well
 // also kind of messy... oh well
-module flared_support(stem_type, loft, height) {
+module flared(stem_type, loft, height) {
   translate([0,0,loft]){
     if (stem_type == "cherry_rounded") {
       linear_extrude(height=height, scale = scale_for_45(height, $rounded_cherry_stem_d)){

--- a/key/src/supports/flat.scad
+++ b/key/src/supports/flat.scad
@@ -1,4 +1,4 @@
-module flat_support(stem_type, loft, height) {
+module flat(stem_type, loft, height) {
   translate([0,0,loft + 500]){
     cube(1000, center=true);
   }


### PR DESCRIPTION
The idea would be to auto-expand `include` and `use` statements via a script, making the customizer script a lot easier to generate. last time I did it by hand and it took like an hour, that's no fun.

currently `keys.scad` uses, not includes, `key.scad`, which is afaict a bit more complex than an include. I'm sure there's a language parsing plugin in Ruby I could look into but since this is only for my project, for now I just crop the one line I don't care about.

this PR expanded to include general cleanup for getting everything to work in customizer. I also spent a couple hours working out an intersection-based dishing function due to a bug in customizer to realize that it wasn't the cause of the bug at all. Oh well, it's a bit faster now.